### PR TITLE
FYI: another extra for managing headers

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -221,6 +221,27 @@ class Markdown(object):
             self._escape_table['"'] = _hash_ascii('"')
             self._escape_table["'"] = _hash_ascii("'")
 
+        if 'tag-friendly-headers' in self.extras:
+            self._atx_h_re = re.compile(r'''
+                ^(\#{1,6})  # \1 = string of #'s
+                [ \t]+
+                (.+?)       # \2 = Header text
+                [ \t]*
+                (?<!\\)     # ensure not an escaped trailing '#'
+                \#*         # optional closing #'s (not counted)
+                \n+
+                ''', re.X | re.M)
+        else:
+            self._atx_h_re = re.compile(r'''
+                ^(\#{1,6})  # \1 = string of #'s
+                [ \t]*
+                (.+?)       # \2 = Header text
+                [ \t]*
+                (?<!\\)     # ensure not an escaped trailing '#'
+                \#*         # optional closing #'s (not counted)
+                \n+
+                ''', re.X | re.M)
+
     def reset(self):
         self.urls = {}
         self.titles = {}
@@ -1187,15 +1208,15 @@ class Markdown(object):
             self._toc_add_entry(n, header_id, html)
         return "<h%d%s>%s</h%d>\n\n" % (n, header_id_attr, html, n)
 
-    _atx_h_re = re.compile(r'''
-        ^(\#{1,6})  # \1 = string of #'s
-        [ \t]*
-        (.+?)       # \2 = Header text
-        [ \t]*
-        (?<!\\)     # ensure not an escaped trailing '#'
-        \#*         # optional closing #'s (not counted)
-        \n+
-        ''', re.X | re.M)
+    # _atx_h_re = re.compile(r'''
+    #     ^(\#{1,6})  # \1 = string of #'s
+    #     [ \t]*
+    #     (.+?)       # \2 = Header text
+    #     [ \t]*
+    #     (?<!\\)     # ensure not an escaped trailing '#'
+    #     \#*         # optional closing #'s (not counted)
+    #     \n+
+    #     ''', re.X | re.M)
     def _atx_h_sub(self, match):
         n = len(match.group(1))
         demote_headers = self.extras.get("demote-headers")


### PR DESCRIPTION
In a project I'm working on, I wanted to be able to capture twitter-style hash tags, but still have markdown format. However, if the #tag was the first thing on a line, it would match the header regex, which wasn't what I wanted. So, now when the extra 'tag-friendly-headers' is passed, whitespace is now required between the opening # and the rest of the header.  Otherwise, the #tag is left as-is.

Example 1:
# tag

standard code: <h1>tag</h1>
w/ my extra: #tag

Example 2:
# header

standard code: <h1>header</h1>
w/ my extra: <h1>header</h1>

Interestingly, this change doesn't break any of the tests... nor is it explicitly dealt with in Gruber's syntax sheets (that I know of).

Feel free to accept or reject the pull as you'd like.
## Commit text

Requires white-space between "#" and the header in order to qualify as a "<h?>"

This lets us include hash-tags (#tagname) as the first item on a line and have it _not_ converted to a <h?>
