### PR TITLE
Fix path.insert() call so it can actually import which and run the tests...

### DIFF
--- a/test/testall.py
+++ b/test/testall.py
@@ -10,7 +10,7 @@ import re
 
 
 TOP = dirname(dirname(abspath(__file__)))
-sys.path.insert(0, join(TOP, "tools", "which"))
+sys.path.insert(0, join(TOP, "tools"))
 import which
 
 


### PR DESCRIPTION
Found this oops when making packages for Ubuntu (https://launchpad.net/~chris-lea/+archive/python-markdown2/).
