### PR TITLE
Added preprocess() and fixed minor bug in atx header regular expression.

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -300,6 +300,8 @@ class Markdown(object):
         if "metadata" in self.extras:
             text = self._extract_metadata(text)
 
+        text = self.preprocess(text)
+
         if self.safe_mode:
             text = self._hash_html_spans(text)
 
@@ -339,6 +341,13 @@ class Markdown(object):
         """A hook for subclasses to do some postprocessing of the html, if
         desired. This is called before unescaping of special chars and
         unhashing of raw HTML spans.
+        """
+        return text
+
+    def preprocess(self, text):
+        """A hook for subclasses to do some preprocessing of the Markdown, if
+        desired. This is called after basic formatting of the text, but prior
+        to any extras, safe mode, etc. processing.
         """
         return text
 


### PR DESCRIPTION
Hey @trentm, we use python-markdown2 at Sprint.ly and love it. We have our own flavoring to our Markdown (auto-linking tickets, URLs, etc.) and wanted to push back two minor changes I made for our own uses.
1. I changed the atx regular expression to require one or more spaces between the # and the header text. It's not explicitly stated on DF as being required, but his examples all show a single space. This keeps comments, hash tags, and ticket numbers at the beginning of the line from turning into an h1.
2. I added a preprocess() method that runs prior to the formatting for sub-classes. It's postprocess()'s cousin.
