### PR TITLE
Allow atx style headers without a space after the #

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1254,7 +1254,7 @@ class Markdown(object):
 
     _atx_h_re = re.compile(r'''
         ^(\#{1,6})  # \1 = string of #'s
-        [ \t]+
+        [ \t]*
         (.+?)       # \2 = Header text
         [ \t]*
         (?<!\\)     # ensure not an escaped trailing '#'
@@ -1262,6 +1262,7 @@ class Markdown(object):
         \n+
         ''', re.X | re.M)
     def _atx_h_sub(self, match):
+        print 'atx match found!'
         n = len(match.group(1))
         demote_headers = self.extras.get("demote-headers")
         if demote_headers:


### PR DESCRIPTION
This is consistent with Markdown.pl
