### PR TITLE
Add break-on-newline option

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -910,7 +910,10 @@ class Markdown(object):
             text = self._do_smart_punctuation(text)
 
         # Do hard breaks:
-        text = re.sub(r" {2,}\n", " <br%s\n" % self.empty_element_suffix, text)
+        if "break-on-newline" in self.extras:
+            text = re.sub(r" *\n", "<br%s\n" % self.empty_element_suffix, text)
+        else:
+            text = re.sub(r" {2,}\n", " <br%s\n" % self.empty_element_suffix, text)
 
         return text
 

--- a/test/tm-cases/break_on_newline.html
+++ b/test/tm-cases/break_on_newline.html
@@ -1,0 +1,10 @@
+<p>Ring forth, ye bells,<br />
+With clarion sound</p>
+
+<p>Forget your knells,<br />
+For joys abound.</p>
+
+<p>Forget your notes<br />
+Of mournful lay,<br />
+And from your throats<br />
+Pour joy to-day.</p>

--- a/test/tm-cases/break_on_newline.opts
+++ b/test/tm-cases/break_on_newline.opts
@@ -1,0 +1,1 @@
+{"extras": ["break-on-newline"]}

--- a/test/tm-cases/break_on_newline.text
+++ b/test/tm-cases/break_on_newline.text
@@ -1,0 +1,10 @@
+Ring forth, ye bells,
+With clarion sound
+
+Forget your knells,
+For joys abound.
+
+Forget your notes
+Of mournful lay,
+And from your throats
+Pour joy to-day.


### PR DESCRIPTION
This changeset adds the option for "break-on-newline" which adds a `<br />` tag on each newline inside a paragraph. This makes the library behave more like [GitHubs markdown](http://github.github.com/github-flavored-markdown/).
