### PR TITLE
prevent exception when unicodedata module not available

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1943,8 +1943,12 @@ def _slugify(value):
 
     From Django's "django/template/defaultfilters.py".
     """
-    import unicodedata
-    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode()
+    try:
+        import unicodedata
+        value = unicodedata.normalize('NFKD', value)
+    except ImportError:
+        pass
+    value = value.encode('ascii', 'ignore').decode()
     value = _slugify_strip_re.sub('', value).strip().lower()
     return _slugify_hyphenate_re.sub('-', value)
 ## end of http://code.activestate.com/recipes/577257/ }}}


### PR DESCRIPTION
Hi,

This patch prevent unhandled exception when using a python version without unicodedata module installed. This has been reported by some users : https://github.com/revolunet/sublimetext-markdown-preview/issues/28

Thanks for the great parser anyway :)
