### PR TITLE
javascript fenced code block parsing error

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -308,6 +308,9 @@ class Markdown(object):
 
         text = self.preprocess(text)
 
+        if "fenced-code-blocks" in self.extras:
+            text = self._do_fenced_code_blocks(text)
+
         if self.safe_mode:
             text = self._hash_html_spans(text)
 


### PR DESCRIPTION
use extras = ['fenced-code-block']. when fenced code block is javascript, markdown2 parses some md5 strings..

for example:

``````
```javascript
<script type="text/javascript" src="{{ static_url('shadowbox/shadowbox.js') }}">
</script>
<script type="text/javascript">
Shadowbox.init({ handleOversize: "drag" });
window.onload = function() {
    Shadowbox.setup(".entry-content img", { gallery: "{{post.title}}", counterType: "skip" });
};
</script>
```
``````

is parsed to:

```
<div class="codehilite"><pre><code><span class="nx">md5</span><span class="o">-</span><span class="mi">26</span><span class="nx">a31e11f9061693a9bf87e6a0855ef5</span>
```

the right result should be:

``` javascript
<script type="text/javascript" src="{{ static_url('shadowbox/shadowbox.js') }}">
</script>
<script type="text/javascript">
Shadowbox.init({ handleOversize: "drag" });
window.onload = function() {
    Shadowbox.setup(".entry-content img", { gallery: "{{post.title}}", counterType: "skip" });
};
</script>
```
