### PR TITLE
Allow nested parentheses in link URLs

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1005,9 +1005,9 @@ class Markdown(object):
           \(            # literal paren
             [ \t]*
             (?P<url>            # \1
-                <.*?>
+                <[^ \t'"]*>
                 |
-                .*?
+                [^ \t'"]*
             )
             [ \t]*
             (                   # \2

--- a/test/markdowntest-cases/Parens in urls.html
+++ b/test/markdowntest-cases/Parens in urls.html
@@ -1,0 +1,5 @@
+<p><a href="/ur(inparen)l/">link text</a></p>
+
+<p><a href="/ur(inparen)l/" title="title">link text</a></p>
+
+<p><a href="/ur(inparen)l/" title="title">link text</a></p>

--- a/test/markdowntest-cases/Parens in urls.text
+++ b/test/markdowntest-cases/Parens in urls.text
@@ -1,0 +1,5 @@
+[link text](/ur(inparen)l/)
+
+[link text](/ur(inparen)l/ "title")
+
+[link text](/ur(inparen)l/ 'title')


### PR DESCRIPTION
Some websites (I'm looking at you, MSDN) have parentheses within their URLs (e.g. http://msdn.microsoft.com/en-us/library/windows/desktop/aa383857(v=vs.85).aspx). This commit performs a greedy match on the URL while preserving the title.
