### PR TITLE
Make makefile compatible with Ubuntu which uses sh as the default shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # python-markdown2 Makefile
+SHELL=/bin/bash
 
 .PHONY: all
 all:


### PR DESCRIPTION
`[[` is a bash-ism. Ubuntu switched to `sh` as the default shell and without this change `make pygments` says: `/bin/sh: 1: [[: not found`
