### PR TITLE
Provided a method for URL resolution.

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1837,7 +1837,7 @@ class Markdown(object):
 
     _auto_link_re = re.compile(r'<((https?|ftp):[^\'">\s]+)>', re.I)
     def _auto_link_sub(self, match):
-        g1 = match.group(1)
+        g1 = self.resolve_url(match.group(1))
         return '<a href="%s">%s</a>' % (g1, g1)
 
     _auto_email_link_re = re.compile(r"""

--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -312,6 +312,43 @@ class DocTestsTestCase(unittest.TestCase):
             doctest.testmod(markdown2)
 
 
+class APITestsTestCase(unittest.TestCase):
+    """Tests for API hooks."""
+
+    def setUp(self):
+        from markdown2 import Markdown
+
+        class ResolveURLMarkdown(Markdown):
+            def resolve_url(self, url):
+                return url + ('&' if '?' in url else '?') + 'tack=on'
+
+        self.resolve_url_markdown = ResolveURLMarkdown()
+
+    def test_resolve_url(self):
+        self.assertEqual(
+            self.resolve_url_markdown.convert('[ref][]\n\n[ref]: some-url'),
+            '<p><a href="some-url?tack=on">ref</a></p>\n')
+        self.assertEqual(
+            self.resolve_url_markdown.convert('[inline](some-url)'),
+            '<p><a href="some-url?tack=on">inline</a></p>\n')
+        self.assertEqual(
+            self.resolve_url_markdown.convert(
+                '![ref][]\n\n[ref]: some-url'),
+            '<p><img src="some-url?tack=on" alt="ref" /></p>\n')
+        self.assertEqual(
+            self.resolve_url_markdown.convert('![inline](some-url)'),
+            '<p><img src="some-url?tack=on" alt="inline" /></p>\n')
+        self.assertEqual(
+            self.resolve_url_markdown.convert('<http://some-url>'),
+            '<p><a href="http://some-url?tack=on">'
+            'http://some-url?tack=on</a></p>\n')
+        # Just shows relative URLs in autolinks can't work anyway
+        # (can't tell from HTML tags, really):
+        self.assertEqual(
+            self.resolve_url_markdown.convert('<relative/link>'),
+            '<p><relative/link></p>\n')
+                
+
 
 #---- internal support stuff
 
@@ -563,3 +600,4 @@ def test_cases():
     yield PHPMarkdownExtraTestCase
     yield DirectTestCase
     yield DocTestsTestCase
+    yield APITestsTestCase


### PR DESCRIPTION
With this, you can subclass Markdown and override resolve_url to do
things like updating relative links to absolute, or rewriting links
based on where the output is to be delivered.
