### PR TITLE
Slight improvement to html-classes.

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1213,6 +1213,10 @@ class Markdown(object):
                     is_img = start_idx > 0 and text[start_idx-1] == "!"
                     if is_img:
                         start_idx -= 1
+                        img_is_start = start_idx <= 0 or \
+                            text[start_idx-1] == "\n"
+                        img_is_end = match.end() >= len(text) or \
+                            text[match.end()] == "\n"
                     link_id = match.group("id").lower()
                     if not link_id:
                         link_id = link_text.lower()  # for links like [this][]
@@ -1232,7 +1236,13 @@ class Markdown(object):
                         else:
                             title_str = ''
                         if is_img:
-                            img_class_str = self._html_class_str_from_tag("img")
+                            tag_search = "img"
+                            if img_is_start:
+                                tag_search += " start"
+                            if img_is_end:
+                                tag_search += " end"
+                            img_class_str = self._html_class_str_from_tag(
+                                tag_search)
                             result = '<img src="%s" alt="%s"%s%s%s' \
                                 % (url.replace('"', '&quot;'),
                                    link_text.replace('"', '&quot;'),

--- a/test/tm-cases/html_classes2.html
+++ b/test/tm-cases/html_classes2.html
@@ -1,0 +1,11 @@
+<p><img src="start1.jpg" alt="" class="start-class" /> With text flowing after.</p>
+
+<p>With text flowing before. <img src="end1.jpg" alt="" class="end-class" /></p>
+
+<p><img src="standalone1.jpg" alt="" class="start-end-class" /></p>
+
+<p><img src="start2.jpg" alt="ref1" class="start-class" /> With text flowing after.</p>
+
+<p>With text flowing before. <img src="end2.jpg" alt="ref2" class="end-class" /></p>
+
+<p><img src="standalone2.jpg" alt="ref3" class="start-end-class" /></p>

--- a/test/tm-cases/html_classes2.opts
+++ b/test/tm-cases/html_classes2.opts
@@ -1,0 +1,8 @@
+{'extras': {
+    'html-classes': {
+        'img start': 'start-class',
+        'img end': 'end-class',
+        'img start end': 'start-end-class',
+    },
+}}
+

--- a/test/tm-cases/html_classes2.tags
+++ b/test/tm-cases/html_classes2.tags
@@ -1,0 +1,1 @@
+extras html-classes knownfailure code.as.com

--- a/test/tm-cases/html_classes2.text
+++ b/test/tm-cases/html_classes2.text
@@ -1,0 +1,15 @@
+![](start1.jpg) With text flowing after.
+
+With text flowing before. ![](end1.jpg)
+
+![](standalone1.jpg)
+
+![ref1][] With text flowing after.
+
+With text flowing before. ![ref2][]
+
+![ref3][]
+
+[ref1]: start2.jpg
+[ref2]: end2.jpg
+[ref3]: standalone2.jpg


### PR DESCRIPTION
This change causes the html-classes extra to perform class lookups for
"img start" "img end" and "img start end" as well the usual "img" from
before. "start" indicates the image was at the start of a line in the
markdown. "end" indicates the end of a line.

I like to use the position of an image to influence its output. For
instance, an image at the beginning of a line of text might float left
of the following text and an image on a line by itself might be framed
differently.
