### PR TITLE
Footnotes: use a numeric character reference rather than a named entity.

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1797,7 +1797,7 @@ class Markdown(object):
                     '&#8617;</a>' % (id, i+1))
                 if footer[-1].endswith("</p>"):
                     footer[-1] = footer[-1][:-len("</p>")] \
-                        + '&nbsp;' + backlink + "</p>"
+                        + '&#160;' + backlink + "</p>"
                 else:
                     footer.append("\n<p>%s</p>" % backlink)
                 footer.append('</li>')

--- a/test/tm-cases/footnotes.html
+++ b/test/tm-cases/footnotes.html
@@ -7,21 +7,21 @@ them. No, three<sup class="footnote-ref" id="fnref-4"><a href="#fn-4">4</a></sup
 <hr />
 <ol>
 <li id="fn-1">
-<p>Here is the body of the first footnote.&nbsp;<a href="#fnref-1" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
+<p>Here is the body of the first footnote.&#160;<a href="#fnref-1" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
 </li>
 
 <li id="fn-2">
 <p>And of the second footnote.</p>
 
-<p>This one has multiple paragraphs.&nbsp;<a href="#fnref-2" class="footnoteBackLink" title="Jump back to footnote 2 in the text.">&#8617;</a></p>
+<p>This one has multiple paragraphs.&#160;<a href="#fnref-2" class="footnoteBackLink" title="Jump back to footnote 2 in the text.">&#8617;</a></p>
 </li>
 
 <li id="fn-3">
-<p>Here is a footnote body that starts on next line.&nbsp;<a href="#fnref-3" class="footnoteBackLink" title="Jump back to footnote 3 in the text.">&#8617;</a></p>
+<p>Here is a footnote body that starts on next line.&#160;<a href="#fnref-3" class="footnoteBackLink" title="Jump back to footnote 3 in the text.">&#8617;</a></p>
 </li>
 
 <li id="fn-4">
-<p>quickie "that looks like a link ref if not careful"&nbsp;<a href="#fnref-4" class="footnoteBackLink" title="Jump back to footnote 4 in the text.">&#8617;</a></p>
+<p>quickie "that looks like a link ref if not careful"&#160;<a href="#fnref-4" class="footnoteBackLink" title="Jump back to footnote 4 in the text.">&#8617;</a></p>
 </li>
 </ol>
 </div>

--- a/test/tm-cases/footnotes_letters.html
+++ b/test/tm-cases/footnotes_letters.html
@@ -7,17 +7,17 @@ them.</p>
 <hr />
 <ol>
 <li id="fn-foo">
-<p>Here is the body of the first footnote.&nbsp;<a href="#fnref-foo" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
+<p>Here is the body of the first footnote.&#160;<a href="#fnref-foo" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
 </li>
 
 <li id="fn-hyphen-ated">
 <p>And of the second footnote.</p>
 
-<p>This one has multiple paragraphs.&nbsp;<a href="#fnref-hyphen-ated" class="footnoteBackLink" title="Jump back to footnote 2 in the text.">&#8617;</a></p>
+<p>This one has multiple paragraphs.&#160;<a href="#fnref-hyphen-ated" class="footnoteBackLink" title="Jump back to footnote 2 in the text.">&#8617;</a></p>
 </li>
 
 <li id="fn-Capital">
-<p>Here is a footnote body that starts on next line.&nbsp;<a href="#fnref-Capital" class="footnoteBackLink" title="Jump back to footnote 3 in the text.">&#8617;</a></p>
+<p>Here is a footnote body that starts on next line.&#160;<a href="#fnref-Capital" class="footnoteBackLink" title="Jump back to footnote 3 in the text.">&#8617;</a></p>
 </li>
 </ol>
 </div>

--- a/test/tm-cases/footnotes_markup.html
+++ b/test/tm-cases/footnotes_markup.html
@@ -16,7 +16,7 @@ a <a href="http://digg.com">link to digg</a>. And some code:</p>
 </li>
 
 <li id="fn-2">
-<p>This body has markup too, <em>but</em> doesn't end with a code block.&nbsp;<a href="#fnref-2" class="footnoteBackLink" title="Jump back to footnote 2 in the text.">&#8617;</a></p>
+<p>This body has markup too, <em>but</em> doesn't end with a code block.&#160;<a href="#fnref-2" class="footnoteBackLink" title="Jump back to footnote 2 in the text.">&#8617;</a></p>
 </li>
 </ol>
 </div>

--- a/test/tm-cases/footnotes_safe_mode_escape.html
+++ b/test/tm-cases/footnotes_safe_mode_escape.html
@@ -6,7 +6,7 @@
 <li id="fn-1">
 <p>Here is the &lt;em&gt;body&lt;/em&gt; of &lt;span class="yo"&gt;the&lt;/span&gt; footnote.</p>
 
-<p>&lt;div class="blah"&gt;And here is the second para of the footnote.&lt;/div&gt;&nbsp;<a href="#fnref-1" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
+<p>&lt;div class="blah"&gt;And here is the second para of the footnote.&lt;/div&gt;&#160;<a href="#fnref-1" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
 </li>
 </ol>
 </div>

--- a/test/tm-cases/footnotes_underscores.html
+++ b/test/tm-cases/footnotes_underscores.html
@@ -6,15 +6,15 @@
 <hr />
 <ol>
 <li id="fn-1">
-<p>memcpy<em>from</em>tvm&nbsp;<a href="#fnref-1" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
+<p>memcpy<em>from</em>tvm&#160;<a href="#fnref-1" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
 </li>
 
 <li id="fn-2">
-<p><code>memcpy_from_tvm</code>&nbsp;<a href="#fnref-2" class="footnoteBackLink" title="Jump back to footnote 2 in the text.">&#8617;</a></p>
+<p><code>memcpy_from_tvm</code>&#160;<a href="#fnref-2" class="footnoteBackLink" title="Jump back to footnote 2 in the text.">&#8617;</a></p>
 </li>
 
 <li id="fn-3">
-<p>memcpy_from_tvm&nbsp;<a href="#fnref-3" class="footnoteBackLink" title="Jump back to footnote 3 in the text.">&#8617;</a></p>
+<p>memcpy_from_tvm&#160;<a href="#fnref-3" class="footnoteBackLink" title="Jump back to footnote 3 in the text.">&#8617;</a></p>
 </li>
 </ol>
 </div>

--- a/test/tm-cases/mismatched_footnotes.html
+++ b/test/tm-cases/mismatched_footnotes.html
@@ -6,11 +6,11 @@
 <hr />
 <ol>
 <li id="fn-foo">
-<p>Here is the body of the footnote foo.&nbsp;<a href="#fnref-foo" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
+<p>Here is the body of the footnote foo.&#160;<a href="#fnref-foo" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
 </li>
 
 <li id="fn-6">
-<p>Here is the body of the footnote 6.&nbsp;<a href="#fnref-6" class="footnoteBackLink" title="Jump back to footnote 2 in the text.">&#8617;</a></p>
+<p>Here is the body of the footnote 6.&#160;<a href="#fnref-6" class="footnoteBackLink" title="Jump back to footnote 2 in the text.">&#8617;</a></p>
 </li>
 </ol>
 </div>


### PR DESCRIPTION
`&nbsp;` is valid HTML, but not (usually) valid XML, which causes problems when e.g. generating content to be included in an Atom feed. In contrast, `&#160;` is valid in all contexts.
