### PR TITLE
Fix code highlight with safe mode

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1515,8 +1515,20 @@ class Markdown(object):
                 formatter_opts = self.extras['code-color'] or {}
 
         if lexer_name:
+            def unhash_code( codeblock ):
+                for key, sanitized in list(self.html_spans.items()):
+                    codeblock = codeblock.replace(key, sanitized)
+                replacements = [
+                    ("&amp;", "&"),
+                    ("&lt;", "<"),
+                    ("&gt;", ">")
+                ]
+                for old, new in replacements:
+                    codeblock = codeblock.replace(old, new)
+                return codeblock
             lexer = self._get_pygments_lexer(lexer_name)
             if lexer:
+                codeblock = unhash_code( codeblock )
                 colored = self._color_with_pygments(codeblock, lexer,
                                                     **formatter_opts)
                 return "\n\n%s\n\n" % colored

--- a/test/tm-cases/fenced_code_blocks_safe_highlight.html
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight.html
@@ -1,0 +1,12 @@
+<div class="codehilite"><pre><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="k">print</span> <span class="s">&quot;hi&quot;</span>
+</code></pre></div>
+
+<p>That's using the <em>fenced-code-blocks</em> extra with Python
+syntax coloring, if <code>pygments</code> is installed. See
+<a href="http://github.github.com/github-flavored-markdown/">http://github.github.com/github-flavored-markdown/</a>.</p>
+
+<div class="codehilite"><pre><code><span class="k">def</span> <span class="nf">foo</span>
+    <span class="nb">puts</span> <span class="s2">&quot;hi&quot;</span>
+<span class="k">end</span>
+</code></pre></div>

--- a/test/tm-cases/fenced_code_blocks_safe_highlight.opts
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight.opts
@@ -1,0 +1,1 @@
+{"extras": ["fenced-code-blocks"], "safe_mode": "escape"}

--- a/test/tm-cases/fenced_code_blocks_safe_highlight.tags
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight.tags
@@ -1,0 +1,1 @@
+extra fenced-code-blocks pygments

--- a/test/tm-cases/fenced_code_blocks_safe_highlight.text
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight.text
@@ -1,0 +1,14 @@
+```python
+if True:
+    print "hi"
+```
+
+That's using the *fenced-code-blocks* extra with Python
+syntax coloring, if `pygments` is installed. See
+<http://github.github.com/github-flavored-markdown/>.
+
+```ruby
+def foo
+    puts "hi"
+end
+```


### PR DESCRIPTION
Fix for correct code highligh if safe_mode is set to escape.

Pygments creates tokens from hashes [ 'md5', '-', 'hash' ], so pygments has to get unhashed code block to process.
