### PR TITLE
update strong and em substitution routine with code friendly regexp.

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1641,8 +1641,9 @@ class Markdown(object):
         self._escape_table[text] = hashed
         return hashed
 
-    _strong_re = re.compile(r"(\*\*|__)(?=\S)(.+?[*_]*)(?<=\S)\1", re.S)
-    _em_re = re.compile(r"(\*|_)(?=\S)(.+?)(?<=\S)\1", re.S)
+    # see https://code.google.com/p/pagedown/source/browse/Markdown.Converter.js#1165
+    _strong_re = re.compile(r"(^|[\W_])(?:(?!\1)|(?=^))(\*|_)\2(?=\S)([^\r]*?\S)\2\2(?!\2)(?=[\W_]|$)", re.S)
+    _em_re = re.compile(r"(^|[\W_])(?:(?!\1)|(?=^))(\*|_)(?=\S)((?:(?!\2)[^\r])*?\S)\2(?!\2)(?=[\W_]|$)", re.S)
     _code_friendly_strong_re = re.compile(r"\*\*(?=\S)(.+?[*_]*)(?<=\S)\*\*", re.S)
     _code_friendly_em_re = re.compile(r"\*(?=\S)(.+?)(?<=\S)\*", re.S)
     def _do_italics_and_bold(self, text):
@@ -1651,8 +1652,8 @@ class Markdown(object):
             text = self._code_friendly_strong_re.sub(r"<strong>\1</strong>", text)
             text = self._code_friendly_em_re.sub(r"<em>\1</em>", text)
         else:
-            text = self._strong_re.sub(r"<strong>\2</strong>", text)
-            text = self._em_re.sub(r"<em>\2</em>", text)
+            text = self._strong_re.sub(r"\1<strong>\3</strong>", text)
+            text = self._em_re.sub(r"\1<em>\3</em>", text)
         return text
 
     # "smarty-pants" extra: Very liberal in interpreting a single prime as an

--- a/test/tm-cases/footnotes_underscores.html
+++ b/test/tm-cases/footnotes_underscores.html
@@ -1,4 +1,4 @@
-<p>memcpy<em>from</em>tvm</p>
+<p>memcpy_from_tvm</p>
 
 <p>Testing<sup class="footnote-ref" id="fnref-1"><a href="#fn-1">1</a></sup>, more testing <sup class="footnote-ref" id="fnref-2"><a href="#fn-2">2</a></sup>, more<sup class="footnote-ref" id="fnref-3"><a href="#fn-3">3</a></sup>.</p>
 
@@ -6,7 +6,7 @@
 <hr />
 <ol>
 <li id="fn-1">
-<p>memcpy<em>from</em>tvm&#160;<a href="#fnref-1" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
+<p>memcpy <em>from</em> tvm&#160;<a href="#fnref-1" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
 </li>
 
 <li id="fn-2">

--- a/test/tm-cases/footnotes_underscores.text
+++ b/test/tm-cases/footnotes_underscores.text
@@ -2,6 +2,6 @@ memcpy_from_tvm
 
 Testing[^1], more testing [^2], more[^3].
 
-[^1]: memcpy_from_tvm
+[^1]: memcpy _from_ tvm
 [^2]: `memcpy_from_tvm`
 [^3]: memcpy\_from\_tvm


### PR DESCRIPTION
Update for `_do_italics_and_bold` subroutine with code friendly conversion to address https://sprint.ly/product/1/#!/item/7274. 

A unit test, `footnotes_underscores`, is updated so that it respect code friendly conversion. Additional unit test are added in `sprint.ly` repo itself, since these unit test are not interest of markdown2 itself.

Note: This does not use `code_friendly` extra feature of markdown2, since it will disable common use case of em and strong.
