### PR TITLE
Fixes of Quick Usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ As a module:
     >>> markdown2.markdown("*boo!*")  # or use `html = markdown_path(PATH)`
     u'<p><em>boo!</em></p>\n'
 
+    >>> from markdown2 import Markdown
     >>> markdowner = Markdown()
     >>> markdowner.convert("*boo!*")
     u'<p><em>boo!</em></p>\n'


### PR DESCRIPTION
When doing markdowner = Markdown() we should do from markdown2 import Markdown, otherwise it gives NameError : "Markdown" name is not defined. Thanks You.