### PR TITLE
Added markdown-in-html extra to Wiki.

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,4 @@
 - py3: py2.4 test (broken?)
-- add "markdown-in-html" extra to wiki
 - add "smarty-pants" extra to wiki
 - add "html-classes" extra to wiki
 - more on the "code-color" extra wiki page


### PR DESCRIPTION
I added `markdown-in-html` to the [Extras wiki page](https://github.com/trentm/python-markdown2/wiki/Extras) and also created the [`markdown-in-html`](https://github.com/trentm/python-markdown2/wiki/markdown-in-html) page. Removing this item from the TODO list.