### PR TITLE
Python Markdown moved to PyPI and to PythonHosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Markdown.pl. Markdown2 also comes with a number of extensions (called
 from 2.4 to 3.3 (and pypy and jython, though I don't frequently test those).
 
 There is another [Python
-markdown.py](http://www.freewisdom.org/projects/python-markdown/). However, at
+markdown.py](https://pythonhosted.org/Markdown/). However, at
 least at the time this project was started, markdown2.py was faster (see the
 [Performance
 Notes](https://github.com/trentm/python-markdown2/wiki/Performance-Notes)) and,


### PR DESCRIPTION
I changed the link towards the first Python implementation of Markdown. That project moved to PyPI and its home is now at PythonHosted.org.