### PR TITLE
Allow empty table cells

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -853,10 +853,13 @@ class Markdown(object):
         return _pyshell_block_re.sub(self._pyshell_block_sub, text)
 
     def _table_sub(self, match):
+        trim_space_re = '^[ \t\n]+|[ \t\n]+$'
+        trim_bar_re = '^\||\|$'
+
         head, underline, body = match.groups()
 
         # Determine aligns for columns.
-        cols = [cell.strip() for cell in underline.strip(' \t\n').strip('|').split('|')]
+        cols = [cell.strip() for cell in re.sub(trim_bar_re, "", re.sub(trim_space_re, "", underline)).split('|')]
         align_from_col_idx = {}
         for col_idx, col in enumerate(cols):
             if col[0] == ':' and col[-1] == ':':
@@ -868,7 +871,7 @@ class Markdown(object):
 
         # thead
         hlines = ['<table%s>' % self._html_class_str_from_tag('table'), '<thead>', '<tr>']
-        cols = [cell.strip() for cell in head.strip(' \t\n').strip('|').split('|')]
+        cols = [cell.strip() for cell in re.sub(trim_bar_re, "", re.sub(trim_space_re, "", head)).split('|')]
         for col_idx, col in enumerate(cols):
             hlines.append('  <th%s>%s</th>' % (
                 align_from_col_idx.get(col_idx, ''),
@@ -881,7 +884,7 @@ class Markdown(object):
         hlines.append('<tbody>')
         for line in body.strip('\n').split('\n'):
             hlines.append('<tr>')
-            cols = [cell.strip() for cell in line.strip(' \t\n').strip('|').split('|')]
+            cols = [cell.strip() for cell in re.sub(trim_bar_re, "", re.sub(trim_space_re, "", line)).split('|')]
             for col_idx, col in enumerate(cols):
                 hlines.append('  <td%s>%s</td>' % (
                     align_from_col_idx.get(col_idx, ''),

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -856,7 +856,7 @@ class Markdown(object):
         head, underline, body = match.groups()
 
         # Determine aligns for columns.
-        cols = [cell.strip() for cell in underline.strip('| \t\n').split('|')]
+        cols = [cell.strip() for cell in underline.strip(' \t\n').strip('|').split('|')]
         align_from_col_idx = {}
         for col_idx, col in enumerate(cols):
             if col[0] == ':' and col[-1] == ':':
@@ -868,7 +868,7 @@ class Markdown(object):
 
         # thead
         hlines = ['<table%s>' % self._html_class_str_from_tag('table'), '<thead>', '<tr>']
-        cols = [cell.strip() for cell in head.strip('| \t\n').split('|')]
+        cols = [cell.strip() for cell in head.strip(' \t\n').strip('|').split('|')]
         for col_idx, col in enumerate(cols):
             hlines.append('  <th%s>%s</th>' % (
                 align_from_col_idx.get(col_idx, ''),
@@ -881,7 +881,7 @@ class Markdown(object):
         hlines.append('<tbody>')
         for line in body.strip('\n').split('\n'):
             hlines.append('<tr>')
-            cols = [cell.strip() for cell in line.strip('| \t\n').split('|')]
+            cols = [cell.strip() for cell in line.strip(' \t\n').strip('|').split('|')]
             for col_idx, col in enumerate(cols):
                 hlines.append('  <td%s>%s</td>' % (
                     align_from_col_idx.get(col_idx, ''),

--- a/test/tm-cases/tables.html
+++ b/test/tm-cases/tables.html
@@ -311,3 +311,52 @@ the rule is it must have at least a single dash in there.</p>
   
   <p>-- Dr. Seuss</p>
 </blockquote>
+
+<h1>table with blank cells</h1>
+
+<table>
+<thead>
+<tr>
+  <th>Header 1</th>
+  <th></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>Cell 1</td>
+  <td></td>
+</tr>
+<tr>
+  <td></td>
+  <td>Cell 4</td>
+</tr>
+</tbody>
+</table>
+
+<h1>table in blockquote with empty cells</h1>
+
+<blockquote>
+  <table>
+  <thead>
+  <tr>
+    <th></th>
+    <th>Two</th>
+    <th>Three</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>grinch</td>
+    <td>stole</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>green</td>
+    <td><strong>eggs</strong></td>
+    <td>ham</td>
+  </tr>
+  </tbody>
+  </table>
+  
+  <p>-- Dr. Seuss</p>
+</blockquote>

--- a/test/tm-cases/tables.text
+++ b/test/tm-cases/tables.text
@@ -146,7 +146,7 @@ the rule is it must have at least a single dash in there.
 
 > |  | Two | Three |
 > | --- | --- | --- |
-> |grinch|stole| |
+> |grinch|stole||
 > |green|**eggs**|ham|
 >
 > -- Dr. Seuss

--- a/test/tm-cases/tables.text
+++ b/test/tm-cases/tables.text
@@ -126,12 +126,27 @@ the rule is it must have at least a single dash in there.
 | `Cell 1` | [Cell 2](http://example.com) link |
 | Cell 3 | **Cell 4** |
 
-
 # table in blockquote
 
 > | One | Two | Three |
 > | --- | --- | --- |
 > |grinch|stole|xmas|
+> |green|**eggs**|ham|
+>
+> -- Dr. Seuss
+
+# table with blank cells
+
+ | Header 1 |  |
+ | -------- | -------- |
+ | Cell 1 |          |
+ |  | Cell 4 |
+
+# table in blockquote with empty cells
+
+> |  | Two | Three |
+> | --- | --- | --- |
+> |grinch|stole| |
 > |green|**eggs**|ham|
 >
 > -- Dr. Seuss


### PR DESCRIPTION
This change allows for empty cells in tables when using the 'tables' extra. Given an input like 

> \| K        \| d_Src        \| Function         \| d_Dst         \| Jmp Cmd         \| Jmp_Dest        \| Jmp Test \|
> \| -------- \| ------------ \| ---------------- \| ------------- \| --------------- \| --------------- \| -------- \|
> \|          \| \`src\`        \| \`ps\`             \|               \|                 \|                 \|          \|

The trim's replaced in this pull request would greedily consume all of the spaces and |'s leaving only two cells instead of seven, and cells end up moved the left side, something like this:

> | K        | d_Src        | Function         | d_Dst         | Jmp Cmd         | Jmp_Dest        | Jmp Test |
> | -------- | ------------ | ---------------- | ------------- | --------------- | --------------- | -------- |
> | `src`        | `ps`             |

Github renders the same input correctly:

| K        | d_Src        | Function         | d_Dst         | Jmp Cmd         | Jmp_Dest        | Jmp Test |
| -------- | ------------ | ---------------- | ------------- | --------------- | --------------- | -------- |
|          | `src`        | `ps`             |               |                 |                 |          |

Five unit tests fail before and after the changes:

> FAIL: markdown2/tm/fenced_code_blocks_safe_highlight [extra, fenced-code-blocks, pygments]
> FAIL: markdown2/tm/fenced_code_blocks_syntax_highlighting [extra, fenced-code-blocks, pygments]
> FAIL: markdown2/tm/fenced_code_blocks_syntax_indentation [extra, fenced-code-blocks, pygments, indentation]
> FAIL: markdown2/tm/issue3_bad_code_color_hack [extra, code-color, unicode, pygments, issue3]
> FAIL: markdown2/tm/syntax_color [extra, code-color, pygments]


