### PR TITLE
Add a case: leading paragraph in fenced_code_blocks.

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1657,7 +1657,7 @@ class Markdown(object):
         return code_block_re.sub(self._code_block_sub, text)
 
     _fenced_code_block_re = re.compile(r'''
-        (?:\n\n|\A\n?)
+        (?:\n+|\A\n?)
         ^```([\w+-]+)?[ \t]*\n      # opening fence, $1 = optional lang
         (.*?)                       # $2 = code block content
         ^```[ \t]*\n                # closing fence

--- a/test/tm-cases/fenced_code_blocks_leading_paragraph.html
+++ b/test/tm-cases/fenced_code_blocks_leading_paragraph.html
@@ -1,5 +1,4 @@
 <p>This is python code.</p>
 
-<pre><code>import os
-print(os.listdir('.'))
+<pre><code>print 'hello'
 </code></pre>

--- a/test/tm-cases/fenced_code_blocks_leading_paragraph.html
+++ b/test/tm-cases/fenced_code_blocks_leading_paragraph.html
@@ -1,0 +1,5 @@
+<p>This is python code.</p>
+
+<pre><code>import os
+print(os.listdir('.'))
+</code></pre>

--- a/test/tm-cases/fenced_code_blocks_leading_paragraph.opts
+++ b/test/tm-cases/fenced_code_blocks_leading_paragraph.opts
@@ -1,0 +1,1 @@
+{"extras": ["fenced-code-blocks"]}

--- a/test/tm-cases/fenced_code_blocks_leading_paragraph.tags
+++ b/test/tm-cases/fenced_code_blocks_leading_paragraph.tags
@@ -1,0 +1,1 @@
+extra fenced-code-blocks 

--- a/test/tm-cases/fenced_code_blocks_leading_paragraph.text
+++ b/test/tm-cases/fenced_code_blocks_leading_paragraph.text
@@ -1,0 +1,5 @@
+This is python code.
+```python
+import os
+print(os.listdir('.'))
+```

--- a/test/tm-cases/fenced_code_blocks_leading_paragraph.text
+++ b/test/tm-cases/fenced_code_blocks_leading_paragraph.text
@@ -1,5 +1,4 @@
 This is python code.
-```python
-import os
-print(os.listdir('.'))
+```
+print 'hello'
 ```


### PR DESCRIPTION
Hi, I met a problem when I want to convert my article written by others markdown editor like [Dillinger](http://dillinger.io/).

The problem in code block.

The input:
<pre>
This is python code.
```python
import os
print(os.listdir('.'))
```
</pre>


The output:
```
<p>This is python code.
<code>python
import os
print(os.listdir('.'))
</code></p>
```

But expected output is this:
```
<p>This is python code.</p>

<pre><code>import os
print(os.listdir('.'))
</code></pre>
```

I think most markdown editor suppor this, but markdown2 don't.
So I try to support this.
I have add some test, and all others test has been pass.