### PR TITLE
make metadata fences optional

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -371,18 +371,29 @@ class Markdown(object):
         """
         return text
 
-    # Is metadata if the content starts with '---'-fenced `key: value`
+    # Is metadata if the content starts with optional '---'-fenced `key: value`
     # pairs. E.g. (indented for presentation):
     #   ---
     #   foo: bar
     #   another-var: blah blah
     #   ---
-    _metadata_pat = re.compile("""^---[ \t]*\n((?:[ \t]*[^ \t:]+[ \t]*:[^\n]*\n)+)---[ \t]*\n""")
+    #   # header
+    # or:
+    #   foo: bar
+    #   another-var: blah blah
+    #   
+    #   # header
+
+    _metadata_pat = re.compile(r"""
+        ^
+        (?:---[\ \t]*\n)?                       # optional "---"
+        ((?:[ \t]*[^ \t:]+[\ \t]*:[^\n]*\n)+)   # "key: value" pairs
+        (?:---[ \t]*)?                          # optional "---"
+        \n""",
+        re.VERBOSE
+    )
 
     def _extract_metadata(self, text):
-        # fast test
-        if not text.startswith("---"):
-            return text
         match = self._metadata_pat.match(text)
         if not match:
             return text

--- a/test/tm-cases/metadata2.html
+++ b/test/tm-cases/metadata2.html
@@ -1,0 +1,3 @@
+<h1>The real text</h1>
+
+<p>This should be parsed as before</p>

--- a/test/tm-cases/metadata2.metadata
+++ b/test/tm-cases/metadata2.metadata
@@ -1,0 +1,7 @@
+{
+  "test": "abc",
+  "leading~space": "is okay",
+  "And": "some, cvs, data, which, you, must, parse, yourself",
+  "this-is": "a hyphen test",
+  "empty": ""
+}

--- a/test/tm-cases/metadata2.opts
+++ b/test/tm-cases/metadata2.opts
@@ -1,0 +1,1 @@
+{"extras": ["metadata"]}

--- a/test/tm-cases/metadata2.tags
+++ b/test/tm-cases/metadata2.tags
@@ -1,0 +1,1 @@
+extra metadata issue78

--- a/test/tm-cases/metadata2.text
+++ b/test/tm-cases/metadata2.text
@@ -1,0 +1,9 @@
+test: abc
+this-is : a hyphen test
+    leading~space	: is okay 
+ And: some, cvs, data, which, you, must, parse, yourself
+empty   :
+
+# The real text
+
+This should be parsed as before


### PR DESCRIPTION
`Markdown` package supports parsing metadata without mandatory "---"-wrapping. The fix enables to write metadata like this:

    some: metadata
    other: stuff

    # here starts usual content

so the top metadata can be separated by a single blank line.