### PR TITLE
Added Numbering

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -866,8 +866,8 @@ class Markdown(object):
         for match in reversed(list(self.regex_subs.finditer(text))):
             number, counter = references.get(match.group(1), (None, None))
             if number is not None:
-                repl = reference_html.format(match.group(1),
-                                             counter,
+                repl = reference_html.format(counter,
+                                             match.group(1),
                                              number)
             else:
                 repl = reference_html.format(match.group(1),
@@ -877,7 +877,6 @@ class Markdown(object):
                 repl = repl.replace('"', self._escape_table['"'])
 
             text = text[:match.start()] + repl + text[match.end():]
-        print(text)
         return text
 
     def _extract_footnote_def_sub(self, match):

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -770,60 +770,6 @@ class Markdown(object):
     def _do_numbering(self, text):
         ''' We handle the special extension for generic numbering for
             tables, figures etc.
-
-            We do two passes through the document.
-            Firstly find all the definitions of an id. These
-            look like [#name text_1 @idname text_2].
-
-            If the counter 'countername' doesn't exist then we create it and
-            initialise it at 1.
-            Then we create a reference called 'idname' which refers to the
-            current value of the counter(val).  We replace the
-            entire match with
-
-            <figcaption class="name" id="counter-ref-idname">text_1 val text_2</figgcaption>
-
-            Then Increment the counter and continue. On the second pass,
-            we look for reference links of the form [@idname].
-            When we find them, we replace the entire match with
-
-            <a class="name" href="#counter-ref-idname">val</span>
-
-            The counters and ids are defined as a word (\w+).
-            The optional text can't contain ']' or '@'
-
-            Using CSS, one can style the figcaption for each counter
-            differently and style the references differently too.
-            See the wiki article (when it's written) for details.
-
-            There is nothing formal linking an id to a counter.
-            If you define an id "spam" in counter "foocounter" and
-            another "spam" in "barcounter" then the results will
-            be...odd.
-
-            Also, this lack of semantics means you can do stupid things.
-
-                <img src="foo.png"></img>
-                [#tablecounter Image @nicefigure: blah blah]
-
-                Equation [@nicefigure] isn't an equation.
-
-            and so on.  The easy solution is not to be stupid.
-
-            Don't put numbers in your link definitions.  If you
-            call an image @imageone and refer to it in the text
-            and then add another image above it then the Markdown
-            will be confusing.  Give images, figures, tables
-            ids that reflect their contents.
-
-            Fwiw, this is a weakness in the current Footnotes
-            implementation.  It's tempting to *number* the footnotes
-            rather than name them.  All sorts of pain is generated
-            by this.
-
-            Finally, if this change is accepted into the main branch and
-            released almost all of the documentation above will be moved
-            into a Wiki entry on "numbering" but for now it's here
         '''
         # First pass to define all the references
         self.regex_defns = re.compile(r'''

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -816,10 +816,6 @@ class Markdown(object):
             text_before = match.group(2)
             ref_id = match.group(3)
             text_after = match.group(4)
-            print('Counter  : "{}"'.format(counter))
-            print('Pre Text : "{}"'.format(text_before))
-            print('Reference: "{}"'.format(ref_id))
-            print('Post Text: "{}"'.format(text_after))
             number = counters.get(counter, 1)
             references[ref_id] = (number, counter)
             replacements.append((match.start(0),

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -781,19 +781,49 @@ class Markdown(object):
             current value of the counter(val).  We replace the
             entire match with
 
-            <figcaption class="name">text_1 val text_2</figgcaption>
+            <figcaption class="name" id="counter-ref-idname">text_1 val text_2</figgcaption>
 
             Then Increment the counter and continue. On the second pass,
             we look for reference links of the form [@idname].
             When we find them, we replace the entire match with
 
-            <span class="name">val</span>
+            <a class="name" href="#counter-ref-idname">val</span>
 
             The counters and ids are defined as a word (\w+).
             The optional text can't contain ']' or '@'
 
             Using CSS, one can style the figcaption for each counter
             differently and style the references differently too.
+            See the wiki article (when it's written) for details.
+
+            There is nothing formal linking an id to a counter.
+            If you define an id "spam" in counter "foocounter" and
+            another "spam" in "barcounter" then the results will
+            be...odd.
+
+            Also, this lack of semantics means you can do stupid things.
+
+                <img src="foo.png"></img>
+                [#tablecounter Image @nicefigure: blah blah]
+
+                Equation [@nicefigure] isn't an equation.
+
+            and so on.  The easy solution is not to be stupid.
+
+            Don't put numbers in your link definitions.  If you
+            call an image @imageone and refer to it in the text
+            and then add another image above it then the Markdown
+            will be confusing.  Give images, figures, tables
+            ids that reflect their contents.
+
+            Fwiw, this is a weakness in the current Footnotes
+            implementation.  It's tempting to *number* the footnotes
+            rather than name them.  All sorts of pain is generated
+            by this.
+
+            Finally, if this change is accepted into the main branch and
+            released almost all of the documentation above will be moved
+            into a Wiki entry on "numbering" but for now it's here
         '''
         # First pass to define all the references
         self.regex_defns = re.compile(r'''

--- a/test/tm-cases/numbering.html
+++ b/test/tm-cases/numbering.html
@@ -1,0 +1,40 @@
+<p>This is an image with a caption</p>
+
+<p><img src="https://consequenceofsound.files.wordpress.com/2015/10/screen-shot-2015-10-17-at-6-57-13-pm.png?w=807"</img></p>
+
+<figcaption class="imagenumbers" id="counter-ref-rickroll">Image 1: Let's Rick Roll You</figcaption>
+
+<p>And we can refer to the rickrolling image as Image <a class="imagenumbers" href="#counter-ref-rickroll">1</a>.  There is a second image of something else</p>
+
+<p><img src="https://wonderifyouwonder.files.wordpress.com/2012/02/anchor.jpg"></img></p>
+
+<figcaption class="imagenumbers" id="counter-ref-kent">Figure 2: I for one welcome our new insect overlords</figcaption>
+
+<p>So we can refer to Figure <a class="imagenumbers" href="#counter-ref-rickroll">1</a> and Figure <a class="imagenumbers" href="#counter-ref-kent">2</a> separately.</p>
+
+<h1>Here is a table</h1>
+
+<table>
+<thead>
+<tr>
+  <th>Header 1</th>
+  <th>Header 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>Cell 1</td>
+  <td>Cell 2</td>
+</tr>
+<tr>
+  <td>Cell 3</td>
+  <td>Cell 4</td>
+</tr>
+</tbody>
+</table>
+
+<figcaption class="tablenumbers" id="counter-ref-exampletable">Table 1: An example table</figcaption>
+
+<p>Which we can refer to as table <a class="tablenumbers" href="#counter-ref-exampletable">1</a></p>
+
+<p>And so we are done.</p>

--- a/test/tm-cases/numbering.opts
+++ b/test/tm-cases/numbering.opts
@@ -1,0 +1,1 @@
+{"extras": ["numbering"]}

--- a/test/tm-cases/numbering.text
+++ b/test/tm-cases/numbering.text
@@ -1,0 +1,40 @@
+<p>This is an image with a caption</p>
+
+<p><img src="https://consequenceofsound.files.wordpress.com/2015/10/screen-shot-2015-10-17-at-6-57-13-pm.png?w=807"</img></p>
+
+<figcaption class="imagenumbers" id="counter-ref-rickroll">Image 1: Let's Rick Roll You</figcaption>
+
+<p>And we can refer to the rickrolling image as Image <a class="imagenumbers" href="#counter-ref-rickroll">1</a>.  There is a second image of something else</p>
+
+<p><img src="https://wonderifyouwonder.files.wordpress.com/2012/02/anchor.jpg"></img></p>
+
+<figcaption class="imagenumbers" id="counter-ref-kent">Figure 2: I for one welcome our new insect overlords</figcaption>
+
+<p>So we can refer to Figure <a class="imagenumbers" href="#counter-ref-rickroll">1</a> and Figure <a class="imagenumbers" href="#counter-ref-kent">2</a> separately.</p>
+
+<h1>Here is a table</h1>
+
+<table>
+<thead>
+<tr>
+  <th>Header 1</th>
+  <th>Header 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>Cell 1</td>
+  <td>Cell 2</td>
+</tr>
+<tr>
+  <td>Cell 3</td>
+  <td>Cell 4</td>
+</tr>
+</tbody>
+</table>
+
+<figcaption class="tablenumbers" id="counter-ref-exampletable">Table 1: An example table</figcaption>
+
+<p>Which we can refer to as table <a class="tablenumbers" href="#counter-ref-exampletable">1</a></p>
+
+<p>And so we are done.</p>


### PR DESCRIPTION
Numbering is described in the docstring for the _do_numbering method.

A generic numbering capability which can be used for equations,
figures, tables etc.  Could also be used for footnotes if required.  Still in design mode so looking for comments.