### PR TITLE
Metadata in blocks

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -400,7 +400,8 @@ class Markdown(object):
         "(\w+:\s+>\n\s+[\S\s]+?)(?=\n\w+\s*:\s*\w+\n|\Z)")
 
     def _extract_metadata(self, text):
-        # fast test
+        # fast test, the specification requires the metadata to be at top
+        # and clearly marked with opening and closing 3 dashes
         if not text.startswith("---"):
             return text
         match = self._metadata_pat.match(text)
@@ -416,7 +417,6 @@ class Markdown(object):
         for item in kv + kvm:
             k, v = item.split(":", 1)
             self.metadata[k.strip()] = v.strip()
-
         return tail
 
     _emacs_oneliner_vars_pat = re.compile(r"-\*-\s*([^\r\n]*?)\s*-\*-", re.UNICODE)

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -390,8 +390,7 @@ class Markdown(object):
     #   another-var: blah blah
     #
     #   # header
-    p = re.compile(r'^(?:---[\ \t]*\n)?(.*:\s+>\n\s+[\S\s]+?)(?=\n\w+\s*:\s*\w+\n|\Z)|([\S\w]+\s*:(?! >)[ \t]*.*\n?)(?:---[\ \t]*\n)?', re.MULTILINE)
-    _meta_data_pattern = p
+    _meta_data_pattern = re.compile(r'^(?:---[\ \t]*\n)?(.*:\s+>\n\s+[\S\s]+?)(?=\n\w+\s*:\s*\w+\n|\Z)|([\S\w]+\s*:(?! >)[ \t]*.*\n?)(?:---[\ \t]*\n)?', re.MULTILINE)
     _key_val_pat = re.compile("[\S\w]+\s*:(?! >)[ \t]*.*\n?", re.MULTILINE)
     # this allows key: >
     #                   value

--- a/test/tm-cases/metadata.metadata
+++ b/test/tm-cases/metadata.metadata
@@ -3,5 +3,7 @@
   "leading~space": "is okay",
   "And": "some, cvs, data, which, you, must, parse, yourself",
   "this-is": "a hyphen test",
-  "empty": ""
+  "empty": "",
+  "and some": "long value\n that goes multiline",
+  "another": "example"
 }

--- a/test/tm-cases/metadata.text
+++ b/test/tm-cases/metadata.text
@@ -4,6 +4,10 @@ this-is : a hyphen test
     leading~space	: is okay 
  And: some, cvs, data, which, you, must, parse, yourself
 empty   :
+and some: >
+ long value
+ that goes multiline
+another: example
 ---
 # The real text
 

--- a/test/tm-cases/metadata2.metadata
+++ b/test/tm-cases/metadata2.metadata
@@ -3,5 +3,7 @@
   "leading~space": "is okay",
   "And": "some, cvs, data, which, you, must, parse, yourself",
   "this-is": "a hyphen test",
-  "empty": ""
+  "empty": "",
+  "another long": "long value\n  that goes multiline",
+  "another": "example"
 }

--- a/test/tm-cases/metadata2.text
+++ b/test/tm-cases/metadata2.text
@@ -1,4 +1,3 @@
-
 test: abc
 this-is : a hyphen test
     leading~space	: is okay 

--- a/test/tm-cases/metadata2.text
+++ b/test/tm-cases/metadata2.text
@@ -1,8 +1,10 @@
+---
 test: abc
 this-is : a hyphen test
     leading~space	: is okay 
  And: some, cvs, data, which, you, must, parse, yourself
 empty   :
+---
 
 # The real text
 

--- a/test/tm-cases/metadata2.text
+++ b/test/tm-cases/metadata2.text
@@ -1,10 +1,13 @@
----
+
 test: abc
 this-is : a hyphen test
     leading~space	: is okay 
  And: some, cvs, data, which, you, must, parse, yourself
 empty   :
----
+another long: >
+  long value
+  that goes multiline
+another: example
 
 # The real text
 


### PR DESCRIPTION
This is a fix for #223 

So now you can specify metadata values in an  idented block prefixed by ">". For example:
```

---
test: abc
this-is : a hyphen test
    leading~space	: is okay 
 And: some, cvs, data, which, you, must, parse, yourself
empty   :
and some: >
 long value
 that goes multiline
another: example
---
# The real text

This should be parsed as before

```