### PR TITLE
restrict link protocols in safe mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
   - "2.7"
   - "pypy"
   - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 # command to install dependencies
 install: pip install Pygments==1.6
 # command to run tests

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -75,8 +75,8 @@ see <https://github.com/trentm/python-markdown2/wiki/Extras> for details):
   and ellipses.
 * spoiler: A special kind of blockquote commonly hidden behind a
   click on SO. Syntax per <http://meta.stackexchange.com/a/72878>.
-* tag-friendly: Requires atx style headers to have a space between the # and 
-  the header text. Useful for applications that require twitter style tags to 
+* tag-friendly: Requires atx style headers to have a space between the # and
+  the header text. Useful for applications that require twitter style tags to
   pass through the parser.
 * tables: Tables using the same format as GFM
   <https://help.github.com/articles/github-flavored-markdown#tables> and
@@ -109,7 +109,6 @@ except ImportError:
 import optparse
 from random import random, randint
 import codecs
-from itertools import chain
 
 
 # ---- Python version compat
@@ -1243,6 +1242,7 @@ class Markdown(object):
             url = self._strip_anglebrackets.sub(r'\1', url)
         return url, title, end_idx
 
+    _safe_protocols = re.compile(r'(https?|ftp):', re.I)
     def _do_links(self, text):
         """Turn Markdown link shortcuts into XHTML <a> and <img> tags.
 
@@ -1354,7 +1354,10 @@ class Markdown(object):
                         curr_pos = start_idx + len(result)
                         text = text[:start_idx] + result + text[url_end_idx:]
                     elif start_idx >= anchor_allowed_pos:
-                        result_head = '<a href="%s"%s>' % (url, title_str)
+                        if self.safe_mode and not self._safe_protocols.match(url):
+                            result_head = '<a href="#"%s>' % (title_str)
+                        else:
+                            result_head = '<a href="%s"%s>' % (url, title_str)
                         result = '%s%s</a>' % (result_head, link_text)
                         if "smarty-pants" in self.extras:
                             result = result.replace('"', self._escape_table['"'])
@@ -1404,9 +1407,10 @@ class Markdown(object):
                             curr_pos = start_idx + len(result)
                             text = text[:start_idx] + result + text[match.end():]
                         elif start_idx >= anchor_allowed_pos:
-                            result = '<a href="%s"%s>%s</a>' \
-                                % (url, title_str, link_text)
-                            result_head = '<a href="%s"%s>' % (url, title_str)
+                            if self.safe_mode and not self._safe_protocols.match(url):
+                                result_head = '<a href="#"%s>' % (title_str)
+                            else:
+                                result_head = '<a href="%s"%s>' % (url, title_str)
                             result = '%s%s</a>' % (result_head, link_text)
                             if "smarty-pants" in self.extras:
                                 result = result.replace('"', self._escape_table['"'])

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -109,6 +109,10 @@ except ImportError:
 import optparse
 from random import random, randint
 import codecs
+try:
+    from urllib import quote_plus
+except ImportError:
+    from urllib.parse import quote_plus
 
 
 # ---- Python version compat
@@ -1346,9 +1350,11 @@ class Markdown(object):
                     if is_img:
                         img_class_str = self._html_class_str_from_tag("img")
                         result = '<img src="%s" alt="%s"%s%s%s' \
-                            % (url.replace('"', '&quot;'),
+                            % (_urlencode(url, safe_mode=self.safe_mode),
                                _xml_escape_attr(link_text),
-                               title_str, img_class_str, self.empty_element_suffix)
+                               title_str,
+                               img_class_str,
+                               self.empty_element_suffix)
                         if "smarty-pants" in self.extras:
                             result = result.replace('"', self._escape_table['"'])
                         curr_pos = start_idx + len(result)
@@ -1357,8 +1363,8 @@ class Markdown(object):
                         if self.safe_mode and not self._safe_protocols.match(url):
                             result_head = '<a href="#"%s>' % (title_str)
                         else:
-                            result_head = '<a href="%s"%s>' % (url, title_str)
-                        result = '%s%s</a>' % (result_head, link_text)
+                            result_head = '<a href="%s"%s>' % (_urlencode(url, safe_mode=self.safe_mode), title_str)
+                        result = '%s%s</a>' % (result_head, _xml_escape_attr(link_text))
                         if "smarty-pants" in self.extras:
                             result = result.replace('"', self._escape_table['"'])
                         # <img> allowed from curr_pos on, <a> from
@@ -1399,9 +1405,11 @@ class Markdown(object):
                         if is_img:
                             img_class_str = self._html_class_str_from_tag("img")
                             result = '<img src="%s" alt="%s"%s%s%s' \
-                                % (url.replace('"', '&quot;'),
-                                   link_text.replace('"', '&quot;'),
-                                   title_str, img_class_str, self.empty_element_suffix)
+                                % (_urlencode(url, safe_mode=self.safe_mode),
+                                   _xml_escape_attr(link_text),
+                                   title_str,
+                                   img_class_str,
+                                   self.empty_element_suffix)
                             if "smarty-pants" in self.extras:
                                 result = result.replace('"', self._escape_table['"'])
                             curr_pos = start_idx + len(result)
@@ -1410,7 +1418,7 @@ class Markdown(object):
                             if self.safe_mode and not self._safe_protocols.match(url):
                                 result_head = '<a href="#"%s>' % (title_str)
                             else:
-                                result_head = '<a href="%s"%s>' % (url, title_str)
+                                result_head = '<a href="%s"%s>' % (_urlencode(url, safe_mode=self.safe_mode), title_str)
                             result = '%s%s</a>' % (result_head, link_text)
                             if "smarty-pants" in self.extras:
                                 result = result.replace('"', self._escape_table['"'])
@@ -2444,6 +2452,15 @@ def _xml_encode_email_char_at_random(ch):
         return '&#%s;' % hex(ord(ch))[1:]
     else:
         return '&#%s;' % ord(ch)
+
+
+def _urlencode(attr, safe_mode=False):
+    """Replace special characters in string using the %xx escape."""
+    if safe_mode:
+        escaped = quote_plus(attr).replace('+', ' ')
+    else:
+        escaped = attr.replace('"', '%22')
+    return escaped
 
 
 # ---- mainline

--- a/test/tm-cases/basic_safe_mode.html
+++ b/test/tm-cases/basic_safe_mode.html
@@ -3,3 +3,9 @@
 <p>[HTML_REMOVED]yowzer![HTML_REMOVED]</p>
 
 <p>blah</p>
+
+<p><a href="#">dangerous link</a></p>
+
+<p><a href="#">dangerous link</a></p>
+
+<p><a href="#">dangerous link</a></p>

--- a/test/tm-cases/basic_safe_mode.html
+++ b/test/tm-cases/basic_safe_mode.html
@@ -4,8 +4,26 @@
 
 <p>blah</p>
 
-<p><a href="#">dangerous link</a></p>
+<p>[HTML_REMOVED]alert(1)[HTML_REMOVED]</p>
 
-<p><a href="#">dangerous link</a></p>
+<p><a href="http%3A%2F%2Fexample.com%22onclick%3D%22alert%281%29">link1</a></p>
 
-<p><a href="#">dangerous link</a></p>
+<p><a href="http%3A%2F%2Fexample.com" title="title&quot;onclick=&quot;alert(1)">link2</a></p>
+
+<p><a href="http%3A%2F%2Fexample.com%3E[HTML_REMOVED]alert%281%29[HTML_REMOVED]">link3</a></p>
+
+<p><a href="http%3A%2F%2Fexample.com%3E[HTML_REMOVED]alert%281%29[HTML_REMOVED]">link4 &gt;[HTML_REMOVED]alert(1)[HTML_REMOVED]</a></p>
+
+<p><a href="#">link5</a></p>
+
+<p><a href="#">link6</a></p>
+
+<p><a href="#">link7</a></p>
+
+<p><img src="http%3A%2F%2Fexample.com%22onclick%3D%22alert%281%29" alt="img" /></p>
+
+<p><img src="http%3A%2F%2Fexample.com" alt="img2" title="text&quot;onclick=&quot;alert(1)" /></p>
+
+<p><img src="http%3A%2F%2Fexample.com%3E[HTML_REMOVED]alert%281%29[HTML_REMOVED]" alt="img3" /></p>
+
+<p><img src="javascript:alert(1)"</p>

--- a/test/tm-cases/basic_safe_mode.text
+++ b/test/tm-cases/basic_safe_mode.text
@@ -3,3 +3,11 @@ blah <img src="dangerous"> blah
 <div>yowzer!</div>
 
 blah
+
+[dangerous link](javascript:alert('XSS'))
+
+[dangerous link](&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#88;&#83;&#83;&#39;&#41;)
+
+[dangerous link][1]
+
+[1]: javascript:alert('XSS')

--- a/test/tm-cases/basic_safe_mode.text
+++ b/test/tm-cases/basic_safe_mode.text
@@ -4,10 +4,28 @@ blah <img src="dangerous"> blah
 
 blah
 
-[dangerous link](javascript:alert('XSS'))
+<script>alert(1)</script>
 
-[dangerous link](&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#88;&#83;&#83;&#39;&#41;)
+[link1](http://example.com"onclick="alert(1))
 
-[dangerous link][1]
+[link2](http://example.com "title"onclick="alert(1)")
+
+[link3](http://example.com><script>alert(1)</script>)
+
+[link4 ><script>alert(1)</script>](http://example.com><script>alert(1)</script>)
+
+[link5](javascript:alert('XSS'))
+
+[link6](&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#88;&#83;&#83;&#39;&#41;)
+
+[link7][1]
+
+![img](http://example.com"onclick="alert(1))
+
+![img2](http://example.com "text"onclick="alert(1)")
+
+![img3](http://example.com><script>alert(1)</script>)
+
+<img src="javascript:alert(1)"
 
 [1]: javascript:alert('XSS')

--- a/test/tm-cases/inline_links.html
+++ b/test/tm-cases/inline_links.html
@@ -1,6 +1,6 @@
 <p>an inline <a href="/url/">link</a></p>
 
-<p>a <a href="/url/" title="title">link "with" title</a></p>
+<p>a <a href="/url/" title="title">link &quot;with&quot; title</a></p>
 
 <p>an inline <img src="/url/" alt="image link" /></p>
 

--- a/test/tm-cases/link_defn_spaces_in_url.html
+++ b/test/tm-cases/link_defn_spaces_in_url.html
@@ -1,3 +1,3 @@
-<p>This is <a href="javascript:alert("hi there");">a link</a> and <a href="javascript:alert("hi again");" title="that's twice now">another</a>.</p>
+<p>This is <a href="javascript:alert(%22hi there%22);">a link</a> and <a href="javascript:alert(%22hi again%22);" title="that's twice now">another</a>.</p>
 
 <p>This is a <a href="/images/thumbs/phpThumb.php?src=/archive/img/1241/1241_10_game.jpg&amp;w=200">crazy one</a> from issue18.</p>

--- a/test/tm-cases/long_link.html
+++ b/test/tm-cases/long_link.html
@@ -1,12 +1,12 @@
 <h1>works</h1>
 
-<p><a href="http://tuxdeluxe.org/node/287">wever installation of Kunnafonix was resisted by many of the local organizations they had to work with The local "computer person" resented a solution that was so easy to use that it undermined the power and prestige they received by being the person to consult when a Windows computer had problems</a></p>
+<p><a href="http://tuxdeluxe.org/node/287">wever installation of Kunnafonix was resisted by many of the local organizations they had to work with The local &quot;computer person&quot; resented a solution that was so easy to use that it undermined the power and prestige they received by being the person to consult when a Windows computer had problems</a></p>
 
 <h1>issue 24: these fail</h1>
 
 <p><a href="http://tuxdeluxe.org/node/287">wever installation of Kunnafonix was resisted by many of the local organizations they had to 
-work with The local "computer person" resented a solution that was so easy to use that it undermined 
+work with The local &quot;computer person&quot; resented a solution that was so easy to use that it undermined 
 the power and prestige they received by being the person to consult when a Windows computer had 
 problems</a></p>
 
-<p><a href="http://tuxdeluxe.org/node/287">However installation of Kunnafonix was resisted by many of the local organizations they had to work with The local "computer person" resented a solution that was so easy to use that it undermined the power and prestige they received by being the person to consult when a Windows computer had problems</a></p>
+<p><a href="http://tuxdeluxe.org/node/287">However installation of Kunnafonix was resisted by many of the local organizations they had to work with The local &quot;computer person&quot; resented a solution that was so easy to use that it undermined the power and prestige they received by being the person to consult when a Windows computer had problems</a></p>

--- a/test/tm-cases/xss_quotes.html
+++ b/test/tm-cases/xss_quotes.html
@@ -1,1 +1,1 @@
-<p><img src="http://static.reddit.com/reddit.com.header.png&quot; onload=&quot;alert('javascript injected')" alt="a" /></p>
+<p><img src="http://static.reddit.com/reddit.com.header.png%22 onload=%22alert('javascript injected')" alt="a" /></p>


### PR DESCRIPTION
Related to #51 and #174.

When `safe_mode` is truthy, only allows `http`, `https`, and `ftp` protocols in links to prevent XSS.