### PR TITLE
Add option to disable color highlighting

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 #!/usr/bin/env python
 # Copyright (c) 2012 Trent Mick.
 # Copyright (c) 2007-2008 ActiveState Corp.
@@ -1738,7 +1740,7 @@ class Markdown(object):
                     codeblock = codeblock.replace(old, new)
                 return codeblock
             lexer = self._get_pygments_lexer(lexer_name)
-            if lexer:
+            if lexer and self.extras.get('no-code-highlighting', True) is True:
                 codeblock = unhash_code( codeblock )
                 colored = self._color_with_pygments(codeblock, lexer,
                                                     **formatter_opts)


### PR DESCRIPTION
hi!

I'm using markdown2 for a [sublime text plugin]() but the I don't the color highlighting, even worst, it creates problem. So, I added an option to disable it, call `no-code-highlighting`.

So, the option is `no-code-highlighting` (just an extra)

```python
import markdown2
markdown2.markdown("""
\```python
import this
\```
""", extras=["no-code-highlighting"])
```

(remove the backslashes, it just that github's syntax highlighter was messing around with this if I didn't add them.

Matt