### PR TITLE
improve taks_list extra wrapper html

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1617,7 +1617,7 @@ class Markdown(object):
         (.*)                   # list item text = \2
     ''', re.M | re.X | re.S)
 
-    _task_list_warpper_str = r'<p><input type="checkbox" class="task-list-item-checkbox" %sdisabled>%s</p>'
+    _task_list_warpper_str = r'<input type="checkbox" class="task-list-item-checkbox" %sdisabled> %s'
 
     def _task_list_item_sub(self, match):
         marker = match.group(1)

--- a/test/tm-cases/task_list.html
+++ b/test/tm-cases/task_list.html
@@ -1,4 +1,4 @@
 <ul>
-<li><p><input type="checkbox" class="task-list-item-checkbox" checked disabled>item1</p></li>
-<li><p><input type="checkbox" class="task-list-item-checkbox" disabled>item2</p></li>
+<li><input type="checkbox" class="task-list-item-checkbox" checked disabled> item1</li>
+<li><input type="checkbox" class="task-list-item-checkbox" disabled> item2</li>
 </ul>


### PR DESCRIPTION
Currently, the task-list-wrapper-text is:
`_task_list_warpper_str = r'<p><input type="checkbox" class="task-list-item-checkbox" %sdisabled>%s</p>'`. In my opinion, the `<p>` tag is unnecessary.

I think the better option will be:
`<input type="checkbox" class="task-list-item-checkbox" disabled> %s`, as github also handles in this way.

I also have a simple comment on that PR: <https://github.com/trentm/python-markdown2/pull/218/files#r100302342>