### PR TITLE
Don't let "target-blank-lines" break footnotes

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -258,10 +258,20 @@ class Markdown(object):
 
     # Per <https://developer.mozilla.org/en-US/docs/HTML/Element/a> "rel"
     # should only be used in <a> tags with an "href" attribute.
-    _a_nofollow = re.compile(r"<(a)([^>]*href=)", re.IGNORECASE)
+    _a_nofollow = re.compile(r"""
+        <(a)
+        (
+            [^>]*
+            href=   # href is required
+            ['"]?   # HTML5 attribute values do not have to be quoted
+            [^#'"]  # We don't want to match href values that start with # (like footnotes)
+        )
+        """,
+        re.IGNORECASE | re.VERBOSE
+    )
 
     # Opens the linked document in a new window or tab
-    # should only used in <a> tags with an "target" attribute.
+    # should only used in <a> tags with an "href" attribute.
     # same with _a_nofollow
     _a_blank = _a_nofollow
 

--- a/test/tm-cases/link_nofollow.html
+++ b/test/tm-cases/link_nofollow.html
@@ -1,5 +1,9 @@
 <p><a rel="nofollow" href="http://example.com">link</a></p>
 
+<p><a rel="nofollow" href="http://example.com/test#fragment">foo</a></p>
+
+<p><a href="#fragment">bar</a></p>
+
 <p>Pre-block:</p>
 
 <pre><code>Here is a raw link:
@@ -14,4 +18,6 @@
 <a rel="nofollow" href="//example.com/six">six</a>
 <A rel="nofollow" HREF="http://example.com/seven">seven</A>
 <a rel="nofollow" foo=bar href="http://example.com/eight">eight</a>
+<a rel="nofollow" href="http://example.com/test#fragment">nine</a>
+<a href="#fragment">ten</a>
 </p>

--- a/test/tm-cases/link_nofollow.text
+++ b/test/tm-cases/link_nofollow.text
@@ -1,5 +1,9 @@
 [link](http://example.com)
 
+[foo](http://example.com/test#fragment)
+
+[bar](#fragment)
+
 Pre-block:
 
     Here is a raw link:
@@ -13,6 +17,9 @@ Pre-block:
 <a href="//example.com/six">six</a>
 <A HREF="http://example.com/seven">seven</A>
 <a foo=bar href="http://example.com/eight">eight</a>
+<a href="http://example.com/test#fragment">nine</a>
+<a href="#fragment">ten</a>
 </p>
+
 
 

--- a/test/tm-cases/link_with_blank.html
+++ b/test/tm-cases/link_with_blank.html
@@ -1,1 +1,5 @@
 <p><a target="_blank" href="http://www.example.com">Ref</a></p>
+
+<p><a href="#bar">Foo</a></p>
+
+<p><a target="_blank" href="http://www.example.com/two#three">One</a></p>

--- a/test/tm-cases/link_with_blank.text
+++ b/test/tm-cases/link_with_blank.text
@@ -1,1 +1,5 @@
 [Ref](http://www.example.com)
+
+[Foo](#bar)
+
+[One](http://www.example.com/two#three)


### PR DESCRIPTION
When you have both `target-blank-lines` and `footnotes` extras enabled, the footnotes unexpectedly open in new tabs.

The proposed solution is to make both `target-blank-lines` and `nofollow` extras ignores links that are just a fragment, eg: `#section1`.

The pull request includes updates to the tests.