### PR TITLE
Test on Python 3 versions up to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 # command to install dependencies
 install: pip install Pygments==1.6
 # command to run tests

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ Programming Language :: Python :: 3.0
 Programming Language :: Python :: 3.1
 Programming Language :: Python :: 3.2
 Programming Language :: Python :: 3.3
+Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
 Operating System :: OS Independent
 Topic :: Software Development :: Libraries :: Python Modules
 Topic :: Software Development :: Documentation

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py24, py25, py26, py27, py32, py33, pypy, jython
+envlist = py24, py25, py26, py27, py32, py33, py34, py35, py36, pypy, jython
 
 [testenv]
 commands = make testone


### PR DESCRIPTION
This updates both the tests, and the meta-data in `setup.py` to include versions up to the newest release of Python, version 3.6.