### PR TITLE
Adding new syntax to support nofollow on single links

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1386,7 +1386,10 @@ class Markdown(object):
                         if self.safe_mode and not self._safe_protocols.match(url):
                             result_head = '<a href="#"%s>' % (title_str)
                         else:
-                            result_head = '<a href="%s"%s>' % (_html_escape_url(url, safe_mode=self.safe_mode), title_str)
+                            if url and url[0] == '!':
+                                result_head = '<a rel="nofollow" href="%s"%s>' % (_html_escape_url(url[1:], safe_mode=self.safe_mode), title_str)
+                            else:
+                                result_head = '<a href="%s"%s>' % (_html_escape_url(url, safe_mode=self.safe_mode), title_str)
                         result = '%s%s</a>' % (result_head, _xml_escape_attr(link_text))
                         if "smarty-pants" in self.extras:
                             result = result.replace('"', self._escape_table['"'])

--- a/test/tm-cases/inline_nofollow.html
+++ b/test/tm-cases/inline_nofollow.html
@@ -1,0 +1,27 @@
+<p><a href="http://example.com">link</a></p>
+
+<p><a rel="nofollow" href="http://example.com">link</a></p>
+
+<p><a href="http://example.com/test#fragment">foo</a></p>
+
+<p><a rel="nofollow" href="http://example.com/test#fragment">foo</a></p>
+
+<p><a href="#fragment">bar</a></p>
+
+<p>Pre-block:</p>
+
+<pre><code>Here is a raw link:
+&lt;a href="http://example.com/one"&gt;one&lt;/a&gt;
+</code></pre>
+
+<p>Raw HTML links:
+<a href="http://example.com/two">two</a>
+<a href="http://example.com/three" rel="nofollow">three</a>
+<a href="http://example.com/four" rel="foo">four</a>
+<a>five</a>
+<a href="//example.com/six">six</a>
+<A HREF="http://example.com/seven">seven</A>
+<a foo=bar href="http://example.com/eight">eight</a>
+<a href="http://example.com/test#fragment">nine</a>
+<a href="#fragment">ten</a>
+</p>

--- a/test/tm-cases/inline_nofollow.opts
+++ b/test/tm-cases/inline_nofollow.opts
@@ -1,0 +1,3 @@
+{"extras": ["nofollow"],
+ "nofollow_character": "!",
+}

--- a/test/tm-cases/inline_nofollow.text
+++ b/test/tm-cases/inline_nofollow.text
@@ -1,0 +1,29 @@
+[link](http://example.com)
+
+[link](!http://example.com)
+
+[foo](http://example.com/test#fragment)
+
+[foo](!http://example.com/test#fragment)
+
+[bar](#fragment)
+
+Pre-block:
+
+    Here is a raw link:
+    <a href="http://example.com/one">one</a>
+
+<p>Raw HTML links:
+<a href="http://example.com/two">two</a>
+<a href="http://example.com/three" rel="nofollow">three</a>
+<a href="http://example.com/four" rel="foo">four</a>
+<a>five</a>
+<a href="//example.com/six">six</a>
+<A HREF="http://example.com/seven">seven</A>
+<a foo=bar href="http://example.com/eight">eight</a>
+<a href="http://example.com/test#fragment">nine</a>
+<a href="#fragment">ten</a>
+</p>
+
+
+


### PR DESCRIPTION
I don't know if this is an acceptable change for the project but here is the proposition of adding a syntax for nofollow urls

When only some links on a text require the nofollow attribute this feature is handy. The `!` in front of the url will add the nofollow attribute.

Example:

```
[Example](!http://example.com)
[Example](http://example.com)
```

Produces:

```
<p><a rel="nofollow" href="http://example.com">Example</a>
<a href="http://example.com">Example</a></p>
```