### PR TITLE
Add pipe escaping in table extension

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -978,11 +978,13 @@ class Markdown(object):
     def _table_sub(self, match):
         trim_space_re = '^[ \t\n]+|[ \t\n]+$'
         trim_bar_re = '^\||\|$'
+        split_bar_re = '^\||(?<!\\\\)\|'
+        escape_bar_re = '\\\\\|'
 
         head, underline, body = match.groups()
 
         # Determine aligns for columns.
-        cols = [cell.strip() for cell in re.sub(trim_bar_re, "", re.sub(trim_space_re, "", underline)).split('|')]
+        cols = [re.sub(escape_bar_re, '|', cell.strip()) for cell in re.split(split_bar_re, re.sub(trim_bar_re, "", re.sub(trim_space_re, "", underline)))]
         align_from_col_idx = {}
         for col_idx, col in enumerate(cols):
             if col[0] == ':' and col[-1] == ':':
@@ -994,7 +996,7 @@ class Markdown(object):
 
         # thead
         hlines = ['<table%s>' % self._html_class_str_from_tag('table'), '<thead>', '<tr>']
-        cols = [cell.strip() for cell in re.sub(trim_bar_re, "", re.sub(trim_space_re, "", head)).split('|')]
+        cols = [re.sub(escape_bar_re, '|', cell.strip()) for cell in re.split(split_bar_re, re.sub(trim_bar_re, "", re.sub(trim_space_re, "", head)))]
         for col_idx, col in enumerate(cols):
             hlines.append('  <th%s>%s</th>' % (
                 align_from_col_idx.get(col_idx, ''),
@@ -1007,7 +1009,7 @@ class Markdown(object):
         hlines.append('<tbody>')
         for line in body.strip('\n').split('\n'):
             hlines.append('<tr>')
-            cols = [cell.strip() for cell in re.sub(trim_bar_re, "", re.sub(trim_space_re, "", line)).split('|')]
+            cols = [re.sub(escape_bar_re, '|', cell.strip()) for cell in re.split(split_bar_re, re.sub(trim_bar_re, "", re.sub(trim_space_re, "", line)))]
             for col_idx, col in enumerate(cols):
                 hlines.append('  <td%s>%s</td>' % (
                     align_from_col_idx.get(col_idx, ''),

--- a/test/tm-cases/tables.html
+++ b/test/tm-cases/tables.html
@@ -360,3 +360,22 @@ the rule is it must have at least a single dash in there.</p>
   
   <p>-- Dr. Seuss</p>
 </blockquote>
+
+<h1>escaping of pipes</h1>
+
+<table>
+<thead>
+<tr>
+  <th>A</th>
+  <th>|</th>
+  <th>C | C</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>||</td>
+  <td>BB</td>
+  <td>C</td>
+</tr>
+</tbody>
+</table>

--- a/test/tm-cases/tables.text
+++ b/test/tm-cases/tables.text
@@ -150,3 +150,9 @@ the rule is it must have at least a single dash in there.
 > |green|**eggs**|ham|
 >
 > -- Dr. Seuss
+
+# escaping of pipes
+
+| A  | \| | C \| C |
+|--- |--- | ------ |
+|\|\|| BB | C |


### PR DESCRIPTION
Fixes #169

The table extension was missing pipe escaping: so, token `\|` inside table
must not be treated as a separator. That is how GFM does that.

* Original behaviour was to simply split on pipe character; changed to
  regex to match only pipes without backslash before them.
* Afterwards, all escaped pipes (`\|`) are changed to single pipes (`|`).
* Added test for table with escaped pipes.