### PR TITLE
Drop Python 3.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ python:
   - "3.5"
   - "3.6"
 # command to install dependencies
-install: pip install Pygments
+install: pip install Pygments==1.6
 # command to run tests
 script: make testone

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@ python:
   - "2.6"
   - "2.7"
   - "pypy"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
 # command to install dependencies
-install: pip install Pygments==1.6
+install: pip install Pygments
 # command to run tests
 script: make testone


### PR DESCRIPTION
Drop Python 3.2 support, as many packages no longer support it.