### PR TITLE
Search for items only within metadata header

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -444,8 +444,8 @@ class Markdown(object):
                 return text
             tail = metadata_split[1]
 
-        kv = re.findall(self._key_val_pat, text)
-        kvm = re.findall(self._key_val_block_pat, text)
+        kv = re.findall(self._key_val_pat, metadata_content)
+        kvm = re.findall(self._key_val_block_pat, metadata_content)
         kvm = [item.replace(": >\n", ":", 1) for item in kvm]
 
         for item in kv + kvm:

--- a/test/tm-cases/metadata.html
+++ b/test/tm-cases/metadata.html
@@ -1,3 +1,5 @@
 <h1>The real text</h1>
 
 <p>This should be parsed as before</p>
+
+<p>This should not be included in the metadata: test</p>

--- a/test/tm-cases/metadata.text
+++ b/test/tm-cases/metadata.text
@@ -12,3 +12,5 @@ another: example
 # The real text
 
 This should be parsed as before
+
+This should not be included in the metadata: test

--- a/test/tm-cases/metadata2.html
+++ b/test/tm-cases/metadata2.html
@@ -1,3 +1,5 @@
 <h1>The real text</h1>
 
 <p>This should be parsed as before</p>
+
+<p>This should not be included in the metadata: test</p>

--- a/test/tm-cases/metadata2.text
+++ b/test/tm-cases/metadata2.text
@@ -11,3 +11,5 @@ another: example
 # The real text
 
 This should be parsed as before
+
+This should not be included in the metadata: test


### PR DESCRIPTION
When parsing the metadata key-value pairs, it incorrectly searches the entire text instead of the metadata header.
For example, 

```python
content = """---
Foo: bar
---

This is a test:
"""
md = markdown2.Markdown(extras=['metadata'])
md.convert(content)
print(md.metadata)
```

results in  `{'Foo': 'bar', 'test': ''}` while it should return only `{'Foo': 'bar'}`