### PR TITLE
Add support for highlightjs language class naming in fenced-code-blocks

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -52,6 +52,8 @@ see <https://github.com/trentm/python-markdown2/wiki/Extras> for details):
   implemented in other Markdown processors (tho not in Markdown.pl v1.0.1).
 * header-ids: Adds "id" attributes to headers. The id value is a slug of
   the header text.
+* highlightjs-lang: Allows specifying the language which used for syntax
+  highlighting when using fenced-code-blocks and highlightjs.
 * html-classes: Takes a dict mapping html tag names (lowercase) to a
   string to use for a "class" tag attribute. Currently only supports "img",
   "table", "pre" and "code" tags. Add an issue if you require this for other
@@ -1752,8 +1754,9 @@ class Markdown(object):
                 lexer_name = lexer_name[3:].strip()
                 codeblock = rest.lstrip("\n")   # Remove lexer declaration line.
                 formatter_opts = self.extras['code-color'] or {}
-
-        if lexer_name:
+        
+        # Use pygments only if not using the highlightjs-lang extra
+        if lexer_name and "highlightjs-lang" not in self.extras:
             def unhash_code(codeblock):
                 for key, sanitized in list(self.html_spans.items()):
                     codeblock = codeblock.replace(key, sanitized)
@@ -1774,7 +1777,12 @@ class Markdown(object):
 
         codeblock = self._encode_code(codeblock)
         pre_class_str = self._html_class_str_from_tag("pre")
-        code_class_str = self._html_class_str_from_tag("code")
+
+        if "highlightjs-lang" in self.extras and lexer_name:
+            code_class_str = ' class="%s"' % lexer_name
+        else:
+            code_class_str = self._html_class_str_from_tag("code")
+
         return "\n\n<pre%s><code%s>%s\n</code></pre>\n\n" % (
             pre_class_str, code_class_str, codeblock)
 

--- a/test/tm-cases/highlightjs_lang.html
+++ b/test/tm-cases/highlightjs_lang.html
@@ -1,0 +1,23 @@
+<pre><code class="cpp">here is some cpp code
+</code></pre>
+
+<pre><code class="lang-cpp">some lang-cpp code
+</code></pre>
+
+<pre><code class="language-cpp">and some language-cpp code
+</code></pre>
+
+<pre><code class="nohighlight">some code without highlighting
+</code></pre>
+
+<p>That's using the <em>fenced-code-blocks</em> and <em>highlightjs-lang</em> extra.</p>
+
+<p>Here is an empty one (just to check):</p>
+
+<pre><code class="cpp">
+</code></pre>
+
+<p>Here is one at the end of the file:</p>
+
+<pre><code class="cpp">    is indentation maintained?
+</code></pre>

--- a/test/tm-cases/highlightjs_lang.opts
+++ b/test/tm-cases/highlightjs_lang.opts
@@ -1,0 +1,1 @@
+{"extras": ["fenced-code-blocks", "highlightjs-lang"]}

--- a/test/tm-cases/highlightjs_lang.tags
+++ b/test/tm-cases/highlightjs_lang.tags
@@ -1,0 +1,1 @@
+extra fenced-code-blocks highlightjs-lang

--- a/test/tm-cases/highlightjs_lang.text
+++ b/test/tm-cases/highlightjs_lang.text
@@ -1,0 +1,28 @@
+```cpp
+here is some cpp code
+```
+
+```lang-cpp
+some lang-cpp code
+```
+
+```language-cpp
+and some language-cpp code
+```
+
+```nohighlight
+some code without highlighting
+```
+
+That's using the *fenced-code-blocks* and *highlightjs-lang* extra.
+
+Here is an empty one (just to check):
+
+```cpp
+```
+
+Here is one at the end of the file:
+
+```cpp
+    is indentation maintained?
+```


### PR DESCRIPTION
I prefer *highlightjs* over *pygments* (and I think *highlightjs* is popular enough to warrant adding this support). Generally *highlightjs* is pretty good about auto-detecting the language used in a codeblock, but sometimes it just doesn't work.
In pure `html` one can do something like:
```html
<pre><code class="cpp"> .... </pre></code>
```
*html-classes* doesn't really work since that specifies the class for all codeblocks (can't have different language codeblocks in the same markdown document).

I added a new extra, *highlightjs-lang* which just uses the existing code to extract the language specified for a (fenced) codeblock.