### PR TITLE
Replace md5() with sha256() for hashing

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -141,8 +141,10 @@ DEFAULT_TAB_WIDTH = 4
 
 
 SECRET_SALT = bytes(randint(0, 1000000))
+# MD5 function was previously used for this; the "md5" prefix was kept for
+# backwards compatibility.
 def _hash_text(s):
-    return 'sha256-' + sha256(SECRET_SALT + s.encode("utf-8")).hexdigest()
+    return 'md5-' + sha256(SECRET_SALT + s.encode("utf-8")).hexdigest()[32:]
 
 # Table of hash values for escaped characters:
 g_escape_table = dict([(ch, _hash_text(ch))

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -102,10 +102,7 @@ __author__ = "Trent Mick"
 import sys
 import re
 import logging
-try:
-    from hashlib import md5
-except ImportError:
-    from md5 import md5
+from hashlib import sha256
 import optparse
 from random import random, randint
 import codecs
@@ -145,7 +142,7 @@ DEFAULT_TAB_WIDTH = 4
 
 SECRET_SALT = bytes(randint(0, 1000000))
 def _hash_text(s):
-    return 'md5-' + md5(SECRET_SALT + s.encode("utf-8")).hexdigest()
+    return 'sha256-' + sha256(SECRET_SALT + s.encode("utf-8")).hexdigest()
 
 # Table of hash values for escaped characters:
 g_escape_table = dict([(ch, _hash_text(ch))


### PR DESCRIPTION
For FIPS[0] related installation, the MD5 modules are unavailable, to
the tune of md5() raising an exception.  Using sha256() from the same
hashlib passes the same `make test` and is now FIPS compliant.

[0] http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm