### PR TITLE
[WIP] Moved _do_code_spans call to after _do_links call.

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1089,8 +1089,6 @@ class Markdown(object):
         # These are all the transformations that occur *within* block-level
         # tags like paragraphs, headers, and list items.
 
-        text = self._do_code_spans(text)
-
         text = self._escape_special_chars(text)
 
         # Process anchor and image tags.
@@ -1100,6 +1098,8 @@ class Markdown(object):
         # Must come after _do_links(), because you can use < and >
         # delimiters in inline links like [this](<url>).
         text = self._do_auto_links(text)
+
+        text = self._do_code_spans(text)
 
         if "link-patterns" in self.extras:
             text = self._do_link_patterns(text)


### PR DESCRIPTION
For cases like:
[This link has a code `span`](http://localhost)
(As you can see GitHub does it right)

Calling `_do_code_spans` before processing link was replacing code spans
with `<code>span</code>` tags, which were then being escaped to
`&lt;code&gt;span&lt;/code&gt;` inside the `_do_links`method.

https://github.com/trentm/python-markdown2/issues/259

This is work in progress. I will run test cases and create a new case for this one.
Any help is welcomed.