### PR TITLE
[WIP] Implement inline-toc extra for TOC HTML insertion after first heading

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -396,7 +396,7 @@ class Markdown(object):
             # Use a regex and rely on the HTML structure as opposed to tracking the heading regex's `end()` across all the HTML transformations (unreliable)
             # TODO (Tomas Hubelbauer): Consider looser regex which allows for more attributes in order to to find heading even when more extras add attributes to it (future-proof)
             pattern = r"\<h{} id=[\"\']{}[\"\']\>{}<\/h{}\>".format(level, id, re.escape(name), level)
-            text = re.sub(pattern, "\g<0>\n" + toc_html(self._toc), text)
+            text = re.sub(pattern, "\g<0>\n" + calculate_toc_html(self._toc), text)
         
         rv = UnicodeWithAttrs(text)
         if ("toc" in self.extras or "inline-toc" in self.extras):
@@ -2230,7 +2230,7 @@ class MarkdownWithExtras(Markdown):
 
 # ---- internal support functions
 
-def toc_html(toc):
+def calculate_toc_html(toc):
     """Return the HTML for the current TOC.
 
     This expects the `_toc` attribute to have been set on this instance.
@@ -2270,7 +2270,9 @@ class UnicodeWithAttrs(unicode):
     """
     metadata = None
     _toc = None
-    toc_html = property(toc_html(_toc))
+    def toc_html(self):
+        return calculate_toc_html(self._toc)
+    toc_html = property(toc_html)
 
 ## {{{ http://code.activestate.com/recipes/577257/ (r1)
 _slugify_strip_re = re.compile(r'[^\w\s-]')


### PR DESCRIPTION
Fixes #279

Instead of adding a new CLI switch and trying to figure out whether CLI vs module usage is distinguishable, I have decided to create a sister extra for toc and make if behave the same way, but insert the TOC HTML to the MarkDown HTML (after the first heading) as well as preserving it as a property. This allows CLI usages the flexibility to just replace `toc` with `inline-toc` and get a table of contents right after the first heading without any worries about backwards compatibility or pollution to the CLI switches. I believe this to be the cleanest solution.

@nicholasserra I don't know how to write Python and this design also happened to be the simplest one I think so that allowed me to take a stab at it. I am sure there is plenty to fix, but the PR is quite small so it should not take long to review. I will gladly improve it based on the review comments. This is missing tests currently but AFAICT there are no tests for TOC to begin with. I can add some for both, just wanted to get a first wave of the review first and see if you would accept this before I attempt that.