### PR TITLE
Do not remove anchors in safe_mode

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1406,7 +1406,8 @@ class Markdown(object):
                         curr_pos = start_idx + len(result)
                         text = text[:start_idx] + result + text[url_end_idx:]
                     elif start_idx >= anchor_allowed_pos:
-                        if self.safe_mode and not self._safe_protocols.match(url):
+                        safe_link = self._safe_protocols.match(url) or url.startswith('#')
+                        if self.safe_mode and not safe_link:
                             result_head = '<a href="#"%s>' % (title_str)
                         else:
                             result_head = '<a href="%s"%s>' % (_html_escape_url(url, safe_mode=self.safe_mode), title_str)

--- a/test/tm-cases/fenced_code_blocks_leading_lang_space.tags
+++ b/test/tm-cases/fenced_code_blocks_leading_lang_space.tags
@@ -1,1 +1,1 @@
-extra fenced-code-blocks 
+extra fenced-code-blocks pygments

--- a/test/tm-cases/link_safe_urls.html
+++ b/test/tm-cases/link_safe_urls.html
@@ -1,0 +1,11 @@
+<p><a href="https://www.example.com">Safe link 1</a></p>
+
+<p><a href="http://www.example.com">Safe link 2</a></p>
+
+<p><a href="ftp://www.example.com">Safe link 3</a></p>
+
+<p><a href="#anchor">Safe link 4</a></p>
+
+<p><a href="#">Unsafe link 1</a></p>
+
+<p><a href="#">Unsafe link 2</a></p>

--- a/test/tm-cases/link_safe_urls.opts
+++ b/test/tm-cases/link_safe_urls.opts
@@ -1,0 +1,1 @@
+{"safe_mode": "escape"}

--- a/test/tm-cases/link_safe_urls.tags
+++ b/test/tm-cases/link_safe_urls.tags
@@ -1,0 +1,1 @@
+safe_mode

--- a/test/tm-cases/link_safe_urls.text
+++ b/test/tm-cases/link_safe_urls.text
@@ -1,0 +1,11 @@
+[Safe link 1](https://www.example.com)
+
+[Safe link 2](http://www.example.com)
+
+[Safe link 3](ftp://www.example.com)
+
+[Safe link 4](#anchor)
+
+[Unsafe link 1](unknown://www.example.com)
+
+[Unsafe link 2](example)


### PR DESCRIPTION
This PR fixes the following:
```
>>> markdown('[text](#anchor)')
u'<p><a href="#anchor">text</a></p>\n'

>>> markdown('[text](#anchor)', safe_mode='escape')
u'<p><a href="#">text</a></p>\n'
```

In other words - internal anchors should not be considered unsafe.

Also I've added `pygments` tag to `fenced_code_blocks_leading_lang_space` test because it fails without pygments installed.