### PR TITLE
fixing  `cuddled-lists` with a single list item

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2056,8 +2056,13 @@ class Markdown(object):
                     # text (issue 33). Note the `[-1]` is a quick way to
                     # consider numeric bullets (e.g. "1." and "2.") to be
                     # equal.
-                    if (li and len(li.group(2)) <= 3 and li.group("next_marker")
-                        and li.group("marker")[-1] == li.group("next_marker")[-1]):
+                    if (li and len(li.group(2)) <= 3
+                            and (
+                                    (li.group("next_marker") and li.group("marker")[-1] == li.group("next_marker")[-1])
+                                    or
+                                    li.group("next_marker") is None
+                            )
+                    ):
                         start = li.start()
                         cuddled_list = self._do_lists(graf[start:]).rstrip("\n")
                         assert cuddled_list.startswith("<ul>") or cuddled_list.startswith("<ol>")

--- a/test/tm-cases/cuddled_para_and_list.html
+++ b/test/tm-cases/cuddled_para_and_list.html
@@ -24,9 +24,9 @@ a longer one.</li>
 </ol>
 
 <p>Here is an asterisk,
-* What do you think
+    * What do you think
 about it?</p>
 
 <p>I suggest using version
-8. Oops, now this line is treated
+    8. Oops, now this line is treated
 as a sub-list.</p>

--- a/test/tm-cases/cuddled_para_and_list.html
+++ b/test/tm-cases/cuddled_para_and_list.html
@@ -30,3 +30,21 @@ about it?</p>
 <p>I suggest using version
     8. Oops, now this line is treated
 as a sub-list.</p>
+
+<p>List with single item:</p>
+
+<ul>
+<li>bullet1</li>
+</ul>
+
+<p>Another list with single item:</p>
+
+<ul>
+<li>bullet1</li>
+</ul>
+
+<p>Yet, another list with single item:</p>
+
+<ul>
+<li>bullet1</li>
+</ul>

--- a/test/tm-cases/cuddled_para_and_list.text
+++ b/test/tm-cases/cuddled_para_and_list.text
@@ -15,10 +15,10 @@ And these in order:
 3. bullet3
 
 Here is an asterisk,
-* What do you think
+    * What do you think
 about it?
 
 I suggest using version
-8. Oops, now this line is treated
+    8. Oops, now this line is treated
 as a sub-list.
 

--- a/test/tm-cases/cuddled_para_and_list.text
+++ b/test/tm-cases/cuddled_para_and_list.text
@@ -22,3 +22,11 @@ I suggest using version
     8. Oops, now this line is treated
 as a sub-list.
 
+List with single item:
+* bullet1
+
+Another list with single item:
+  * bullet1
+
+Yet, another list with single item:
+   * bullet1


### PR DESCRIPTION
this hotfix is mainly the resolution of 
https://github.com/trentm/python-markdown2/issues/286