### PR TITLE
DeprecationWarning: invalid escape sequence

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -440,7 +440,7 @@ class Markdown(object):
     #
     #   # header
     _meta_data_pattern = re.compile(r'^(?:---[\ \t]*\n)?(.*:\s+>\n\s+[\S\s]+?)(?=\n\w+\s*:\s*\w+\n|\Z)|([\S\w]+\s*:(?! >)[ \t]*.*\n?)(?:---[\ \t]*\n)?', re.MULTILINE)
-    _key_val_pat = re.compile("[\S\w]+\s*:(?! >)[ \t]*.*\n?", re.MULTILINE)
+    _key_val_pat = re.compile(r"[\S\w]+\s*:(?! >)[ \t]*.*\n?", re.MULTILINE)
     # this allows key: >
     #                   value
     #                   conutiues over multiple lines
@@ -998,9 +998,9 @@ class Markdown(object):
 
     def _table_sub(self, match):
         trim_space_re = '^[ \t\n]+|[ \t\n]+$'
-        trim_bar_re = '^\||\|$'
-        split_bar_re = '^\||(?<!\\\\)\|'
-        escape_bar_re = '\\\\\|'
+        trim_bar_re = r'^\||\|$'
+        split_bar_re = r'^\||(?<!\\)\|'
+        escape_bar_re = r'\\\|'
 
         head, underline, body = match.groups()
 


### PR DESCRIPTION
In Python 3.6, I encountered the following warning messages with `markdown2-2.3.5` when I running test cases in my project:

```
markdown2.py:427: DeprecationWarning: invalid escape sequence \S
  _key_val_pat = re.compile("[\S\w]+\s*:(?! >)[ \t]*.*\n?", re.MULTILINE)
markdown2.py:432: DeprecationWarning: invalid escape sequence \s
  "(.*:\s+>\n\s+[\S\s]+?)(?=\n\w+\s*:\s*\w+\n|\Z)", re.MULTILINE)
markdown2.py:985: DeprecationWarning: invalid escape sequence \|
  trim_bar_re = '^\||\|$'
markdown2.py:986: DeprecationWarning: invalid escape sequence \|
  split_bar_re = '^\||(?<!\\\\)\|'
markdown2.py:987: DeprecationWarning: invalid escape sequence \|
  escape_bar_re = '\\\\\|'
```

These warnings can be avoid by using raw strings.
