### PR TITLE
Fix "make test" in Python 3

### DIFF
--- a/test/testall.py
+++ b/test/testall.py
@@ -3,6 +3,8 @@
 # Run the test suite against all the Python versions we can find.
 #
 
+from __future__ import print_function
+
 import sys
 import os
 from os.path import dirname, abspath, join
@@ -46,7 +48,7 @@ def testall():
             # Don't support Python < 2.3.
             continue
         ver_str = "%s.%s" % ver
-        print "-- test with Python %s (%s)" % (ver_str, python)
+        print("-- test with Python %s (%s)" % (ver_str, python))
         assert ' ' not in python
         rv = os.system("MACOSX_DEPLOYMENT_TARGET= %s test.py -- -knownfailure" % python)
         if rv:

--- a/tools/which.py
+++ b/tools/which.py
@@ -33,6 +33,8 @@ of where the match was found. For example:
     from HKLM\SOFTWARE\...\perl.exe
 """
 
+from __future__ import print_function
+
 _cmdlnUsage = """
     Show the full path of commands.
 
@@ -287,17 +289,17 @@ def main(argv):
     try:
         optlist, args = getopt.getopt(argv[1:], 'haVvqp:e:',
             ['help', 'all', 'version', 'verbose', 'quiet', 'path=', 'exts='])
-    except getopt.GetoptError, msg:
+    except getopt.GetoptError as msg:
         sys.stderr.write("which: error: %s. Your invocation was: %s\n"\
                          % (msg, argv))
         sys.stderr.write("Try 'which --help'.\n")
         return 1
     for opt, optarg in optlist:
         if opt in ('-h', '--help'):
-            print _cmdlnUsage
+            print(_cmdlnUsage)
             return 0
         elif opt in ('-V', '--version'):
-            print "which %s" % __version__
+            print("which %s" % __version__)
             return 0
         elif opt in ('-a', '--all'):
             all = 1
@@ -325,9 +327,9 @@ def main(argv):
         nmatches = 0
         for match in whichgen(arg, path=altpath, verbose=verbose, exts=exts):
             if verbose:
-                print "%s (%s)" % match
+                print("%s (%s)" % match)
             else:
-                print match
+                print(match)
             nmatches += 1
             if not all:
                 break


### PR DESCRIPTION
In Python 3, `make test` failed because of syntaxes not compatible with Python 3.
This PR fixes these errors with remain Python 2 compatibility.
