### PR TITLE
Fix CVE-2018-5773: #285

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1203,7 +1203,7 @@ class Markdown(object):
                 self.html_spans[key] = sanitized
                 tokens.append(key)
             else:
-                tokens.append(token)
+                tokens.append(self._encode_incomplete_tags(token))
             is_html_markup = not is_html_markup
         return ''.join(tokens)
 
@@ -2139,6 +2139,14 @@ class Markdown(object):
         # Markdown) don't do this.
         text = self._naked_gt_re.sub('&gt;', text)
         return text
+
+    _incomplete_tags_re = re.compile("<(/?\w+\s+)")
+
+    def _encode_incomplete_tags(self, text):
+        if self.safe_mode not in ("replace", "escape"):
+            return text
+            
+        return self._incomplete_tags_re.sub("&lt;\\1", text)
 
     def _encode_backslash_escapes(self, text):
         for ch, escape in list(self._escape_table.items()):

--- a/test/tm-cases/CVE-2018-5773.html
+++ b/test/tm-cases/CVE-2018-5773.html
@@ -1,0 +1,3 @@
+<p>&lt;img src="" onerror=alert(/XSS/) </p>
+
+<p>&lt;/img src="" onerror=alert(/XSS/) </p>

--- a/test/tm-cases/CVE-2018-5773.opts
+++ b/test/tm-cases/CVE-2018-5773.opts
@@ -1,0 +1,1 @@
+{"safe_mode": "replace"}

--- a/test/tm-cases/CVE-2018-5773.text
+++ b/test/tm-cases/CVE-2018-5773.text
@@ -1,0 +1,3 @@
+<img src="" onerror=alert(/XSS/) 
+
+</img src="" onerror=alert(/XSS/) 

--- a/test/tm-cases/basic_safe_mode.html
+++ b/test/tm-cases/basic_safe_mode.html
@@ -28,7 +28,7 @@
 
 <p><img src="http://example.com&gt;[HTML_REMOVED]alert(1)[HTML_REMOVED]" alt="img3" /></p>
 
-<p><img src="javascript:alert(1)"</p>
+<p>&lt;img src="javascript:alert(1)"</p>
 
 <p><img src="http://example.com/image.gif?h=200&amp;w=500" alt="ok img" /></p>
 


### PR DESCRIPTION
Add sanitization for incomplete HTML tags.

I believe this PR fix #285 (CVE-2018-5773) as follows:

```pycon
>>> mark('<img src= onerror=alert(/XSS/)>', safe_mode=True)
<p>[HTML_REMOVED]</p>

>>> mark('<img src= onerror=alert(/XSS/) ', safe_mode=True)
<p>&lt;img src="" onerror=alert(/XSS/) </p>

>>> mark('<img src="" onerror=alert(/XSS/)>', safe_mode="escape")
<p>&lt;img src="" onerror=alert(/XSS/)&gt;</p>

>>> mark('<img src="" onerror=alert(/XSS/) ', safe_mode="escape")
<p>&lt;img src="" onerror=alert(/XSS/) </p>
```