### PR TITLE
Add Wheel package support: Issue #228

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include CONTRIBUTORS.txt
 include CHANGES.md
 include Makefile
 include setup.py
+include setup.cfg
 
 include bin/markdown2
 include test/api.doctests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[aliases]
+build=sdist bdist_wheel
+
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@
 
 import os
 import sys
-import distutils
-from distutils.core import setup
+
+from setuptools import setup
 
 _top_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(_top_dir, "lib"))


### PR DESCRIPTION
This PR adds a functionality to make packages for both `tar.gz` and `whl` (Wheel format).
For example:

```con
$ python setup.py build
...
$ ls dist
markdown2-2.3.6-py2.py3-none-any.whl  markdown2-2.3.6.tar.gz
```

You will need to change to specify both packages when uploading packages to PyPI:

```
twine upload dist/markdown2-2.3.6-py2.py3-none-any.whl dist/markdown2-2.3.6.tar.gz
```
