### PR TITLE
Drop support for legacy Python versions: Issue #305

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ was written to closely match the behaviour of the original Perl-implemented
 Markdown.pl. Markdown2 also comes with a number of extensions (called
 "extras") for things like syntax coloring, tables, header-ids. See the
 "Extra Syntax" section below. "markdown2" supports all Python versions
-from 2.4 to 3.3 (and pypy and jython, though I don't frequently test those).
+2.6+ or 3.3+ (and pypy and jython, though I don't frequently test those).
 
 There is another [Python
 markdown.py](https://pythonhosted.org/Markdown/). However, at

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -3,8 +3,6 @@
 # Copyright (c) 2007-2008 ActiveState Corp.
 # License: MIT (http://www.opensource.org/licenses/mit-license.php)
 
-from __future__ import generators
-
 r"""A fast and complete Python implementation of Markdown.
 
 [from http://daringfireball.net/projects/markdown/]
@@ -116,11 +114,6 @@ except ImportError:
 
 
 # ---- Python version compat
-
-if sys.version_info[:2] < (2, 4):
-    def reversed(sequence):
-        for i in sequence[::-1]:
-            yield i
 
 # Use `bytes` for byte strings and `unicode` for unicode strings (str in Py3).
 if sys.version_info[0] <= 2:

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -107,6 +107,7 @@ from hashlib import sha256
 import optparse
 from random import random, randint
 import codecs
+from collections import defaultdict
 try:
     from urllib import quote_plus
 except ImportError:
@@ -266,7 +267,7 @@ class Markdown(object):
             self.footnotes = {}
             self.footnote_ids = []
         if "header-ids" in self.extras:
-            self._count_from_header_id = {}  # no `defaultdict` in Python 2.4
+            self._count_from_header_id = defaultdict(int)
         if "metadata" in self.extras:
             self.metadata = {}
 
@@ -1498,13 +1499,10 @@ class Markdown(object):
         header_id = _slugify(text)
         if prefix and isinstance(prefix, base_string_type):
             header_id = prefix + '-' + header_id
-        if header_id in self._count_from_header_id:
-            self._count_from_header_id[header_id] += 1
+
+        self._count_from_header_id[header_id] += 1
+        if 0 == len(header_id) or self._count_from_header_id[header_id] > 1:
             header_id += '-%s' % self._count_from_header_id[header_id]
-        else:
-            self._count_from_header_id[header_id] = 1
-            if 0 == len(header_id):
-                header_id += '-%s' % self._count_from_header_id[header_id]
 
         return header_id
 

--- a/setup.py
+++ b/setup.py
@@ -18,14 +18,9 @@ Intended Audience :: Developers
 License :: OSI Approved :: MIT License
 Programming Language :: Python
 Programming Language :: Python :: 2
-Programming Language :: Python :: 2.4
-Programming Language :: Python :: 2.5
 Programming Language :: Python :: 2.6
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.0
-Programming Language :: Python :: 3.1
-Programming Language :: Python :: 3.2
 Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5

--- a/setup.py
+++ b/setup.py
@@ -37,14 +37,6 @@ Topic :: Text Processing :: Filters
 Topic :: Text Processing :: Markup :: HTML
 """
 
-if sys.version_info < (2, 3):
-    # Distutils before Python 2.3 doesn't accept classifiers.
-    _setup = setup
-    def setup(**kwargs):
-        if kwargs.has_key("classifiers"):
-            del kwargs["classifiers"]
-        _setup(**kwargs)
-
 script = (sys.platform == "win32" and "lib\\markdown2.py" or "bin/markdown2")
 
 setup(

--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -300,8 +300,6 @@ versions of markdown2.py this was pathologically slow:</p>
 
 class DocTestsTestCase(unittest.TestCase):
     def test_api(self):
-        if sys.version_info[:2] < (2,4):
-            raise TestSkipped("no DocFileTest in Python <=2.3")
         test = doctest.DocFileTest("api.doctests")
         test.runTest()
 

--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -14,13 +14,7 @@ import unittest
 import codecs
 import difflib
 import doctest
-try:
-    from json import loads as json_loads
-except ImportError:
-    def json_loads(s):
-        # Total hack to get support for 2.4. "simplejson" only supports back
-        # to 2.5 now and `json` is only in the Python stdlib >=2.6.
-        return eval(s, {}, {})
+from json import loads as json_loads
 
 from testlib import TestError, TestSkipped, tag
 
@@ -510,12 +504,7 @@ def _escaped_text_from_text(text, escapes="eol"):
     # Sort longer replacements first to allow, e.g. '\r\n' to beat '\r' and
     # '\n'.
     escapes_keys = list(escapes.keys())
-    try:
-        escapes_keys.sort(key=lambda a: len(a), reverse=True)
-    except TypeError:
-        # Python 2.3 support: sort() takes no keyword arguments
-        escapes_keys.sort(lambda a,b: cmp(len(a), len(b)))
-        escapes_keys.reverse()
+    escapes_keys.sort(key=lambda a: len(a), reverse=True)
     def repl(match):
         val = escapes[match.group(0)]
         return val

--- a/test/testall.py
+++ b/test/testall.py
@@ -26,8 +26,7 @@ def _python_ver_from_python(python):
 
 def _gen_python_names():
     yield "python"
-    for ver in [(2,2), (2,3), (2,4), (2,5), (2,6), (2,7), (3,0), (3,1),
-                (3,2), (3,3)]:
+    for ver in [(2,6), (2,7), (3,3), (3,4), (3,5), (3,6)]:
         yield "python%d.%d" % ver
         if sys.platform == "win32":
             yield "python%d%d" % ver
@@ -44,8 +43,8 @@ def _gen_pythons():
 
 def testall():
     for ver, python in _gen_pythons():
-        if ver < (2,3):
-            # Don't support Python < 2.3.
+        if ver < (2,6) or ver in ((3,0), (3,1), (3,2)):
+            # Don't support Python < 2.6, 3.0/3.1/3.2.
             continue
         ver_str = "%s.%s" % ver
         print("-- test with Python %s (%s)" % (ver_str, python))

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -343,15 +343,9 @@ def tests_from_manifest(testdir_from_ns):
             else:
                 testsuite_class = None
             for testcase in testcases_from_testmod(testmod):
-                try:
-                    yield Test(ns, testmod, testcase,
-                               testcase._testMethodName,
-                               testsuite_class)
-                except AttributeError:
-                    # Python 2.4 and older:
-                    yield Test(ns, testmod, testcase,
-                               testcase._TestCase__testMethodName,
-                               testsuite_class)
+                yield Test(ns, testmod, testcase,
+                            testcase._testMethodName,
+                            testsuite_class)
 
 def tests_from_manifest_and_tags(testdir_from_ns, tags):
     include_tags = [tag.lower() for tag in tags if not tag.startswith('-')]


### PR DESCRIPTION
Related to Issue #305
This PR remove or replace source code for support legacy Python versions.
I confirmed that all of the test cases by `make test` are passed after the change.