### PR TITLE
Fix syntax highlighting test cases that depend on Pygments output: Issue #281

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ python:
   - "3.5"
   - "3.6"
 # command to install dependencies
-install: pip install Pygments==1.6
+install: pip install Pygments>=2.1.1
 # command to run tests
 script: make testone

--- a/test/tm-cases/fenced_code_blocks_leading_lang_space.html
+++ b/test/tm-cases/fenced_code_blocks_leading_lang_space.html
@@ -1,3 +1,3 @@
-<div class="codehilite"><pre><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
-    <span class="k">print</span> <span class="s">&quot;hi&quot;</span>
+<div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="k">print</span> <span class="s2">&quot;hi&quot;</span>
 </code></pre></div>

--- a/test/tm-cases/fenced_code_blocks_safe_highlight.html
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight.html
@@ -1,12 +1,12 @@
-<div class="codehilite"><pre><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
-    <span class="k">print</span> <span class="s">&quot;hi&quot;</span>
+<div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="k">print</span> <span class="s2">&quot;hi&quot;</span>
 </code></pre></div>
 
 <p>That's using the <em>fenced-code-blocks</em> extra with Python
 syntax coloring, if <code>pygments</code> is installed. See
 <a href="http://github.github.com/github-flavored-markdown/">http://github.github.com/github-flavored-markdown/</a>.</p>
 
-<div class="codehilite"><pre><code><span class="k">def</span> <span class="nf">foo</span>
+<div class="codehilite"><pre><span></span><code><span class="k">def</span> <span class="nf">foo</span>
     <span class="nb">puts</span> <span class="s2">&quot;hi&quot;</span>
 <span class="k">end</span>
 </code></pre></div>

--- a/test/tm-cases/fenced_code_blocks_syntax_highlighting.html
+++ b/test/tm-cases/fenced_code_blocks_syntax_highlighting.html
@@ -1,12 +1,12 @@
-<div class="codehilite"><pre><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
-    <span class="k">print</span> <span class="s">&quot;hi&quot;</span>
+<div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="k">print</span> <span class="s2">&quot;hi&quot;</span>
 </code></pre></div>
 
 <p>That's using the <em>fenced-code-blocks</em> extra with Python
 syntax coloring, if <code>pygments</code> is installed. See
 <a href="http://github.github.com/github-flavored-markdown/">http://github.github.com/github-flavored-markdown/</a>.</p>
 
-<div class="codehilite"><pre><code><span class="k">def</span> <span class="nf">foo</span>
+<div class="codehilite"><pre><span></span><code><span class="k">def</span> <span class="nf">foo</span>
     <span class="nb">puts</span> <span class="s2">&quot;hi&quot;</span>
 <span class="k">end</span>
 </code></pre></div>

--- a/test/tm-cases/fenced_code_blocks_syntax_indentation.html
+++ b/test/tm-cases/fenced_code_blocks_syntax_indentation.html
@@ -1,5 +1,5 @@
-<div class="codehilite"><pre><code><span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>
-    <span class="k">print</span> <span class="s">&quot;foo&quot;</span>
+<div class="codehilite"><pre><span></span><code><span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>
+    <span class="k">print</span> <span class="s2">&quot;foo&quot;</span>
 
-    <span class="k">print</span> <span class="s">&quot;bar&quot;</span>
+    <span class="k">print</span> <span class="s2">&quot;bar&quot;</span>
 </code></pre></div>

--- a/test/tm-cases/issue3_bad_code_color_hack.html
+++ b/test/tm-cases/issue3_bad_code_color_hack.html
@@ -6,7 +6,7 @@
 
 <p>Some python code:</p>
 
-<div class="codehilite"><pre><code><span class="c"># комментарий</span>
+<div class="codehilite"><pre><span></span><code><span class="c1"># комментарий</span>
 <span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
-    <span class="k">print</span> <span class="s">&quot;hi&quot;</span>
+    <span class="k">print</span> <span class="s2">&quot;hi&quot;</span>
 </code></pre></div>

--- a/test/tm-cases/syntax_color.html
+++ b/test/tm-cases/syntax_color.html
@@ -1,14 +1,14 @@
 <p>Here is some sample code:</p>
 
-<div class="codehilite"><pre><code><span class="kn">import</span> <span class="nn">sys</span>
+<div class="codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">sys</span>
 <span class="k">def</span> <span class="nf">main</span><span class="p">(</span><span class="n">argv</span><span class="o">=</span><span class="n">sys</span><span class="o">.</span><span class="n">argv</span><span class="p">):</span>
     <span class="n">logging</span><span class="o">.</span><span class="n">basicConfig</span><span class="p">()</span>
-    <span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s">&#39;hi&#39;</span><span class="p">)</span>
+    <span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s1">&#39;hi&#39;</span><span class="p">)</span>
 </code></pre></div>
 
 <p>and:</p>
 
-<div class="codehilite"><pre><code><span class="n">use</span> <span class="s1">&#39;zlib&#39;</span>
+<div class="codehilite"><pre><span></span><code><span class="n">use</span> <span class="s1">&#39;zlib&#39;</span>
 <span class="nb">sub</span> <span class="n">main</span><span class="p">(</span><span class="n">argv</span><span class="p">)</span>
     <span class="nb">puts</span> <span class="s1">&#39;hi&#39;</span>
 <span class="k">end</span>

--- a/test/tm-cases/syntax_color_opts.html
+++ b/test/tm-cases/syntax_color_opts.html
@@ -1,6 +1,6 @@
 <p>Here is some sample code:</p>
 
-<div class="codehilite" style="background: #f8f8f8"><pre style="line-height: 125%"><code><span style="color: #008000; font-weight: bold">import</span> <span style="color: #0000FF; font-weight: bold">sys</span>
+<div class="codehilite" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span><code><span style="color: #008000; font-weight: bold">import</span> <span style="color: #0000FF; font-weight: bold">sys</span>
 <span style="color: #008000; font-weight: bold">def</span> <span style="color: #0000FF">main</span>(argv<span style="color: #666666">=</span>sys<span style="color: #666666">.</span>argv):
     logging<span style="color: #666666">.</span>basicConfig()
     log<span style="color: #666666">.</span>info(<span style="color: #BA2121">&#39;hi&#39;</span>)
@@ -8,7 +8,7 @@
 
 <p>and:</p>
 
-<div class="codehilite" style="background: #f8f8f8"><pre style="line-height: 125%"><code>use <span style="color: #BA2121">&#39;zlib&#39;</span>
+<div class="codehilite" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span><code>use <span style="color: #BA2121">&#39;zlib&#39;</span>
 <span style="color: #008000">sub</span> main(argv)
     <span style="color: #008000">puts</span> <span style="color: #BA2121">&#39;hi&#39;</span>
 <span style="color: #008000; font-weight: bold">end</span>


### PR DESCRIPTION
This PR fixes #281.
Looks like `Pygments` changed highlighting output since version 2.1.1
and the changes would not break any HTML appearance from browsers in these test cases.