### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7-dev"
 # command to install dependencies
 install: pip install Pygments>=2.1.1
 # command to run tests

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
 Operating System :: OS Independent
 Topic :: Software Development :: Libraries :: Python Modules
 Topic :: Software Development :: Documentation

--- a/test/testall.py
+++ b/test/testall.py
@@ -26,7 +26,7 @@ def _python_ver_from_python(python):
 
 def _gen_python_names():
     yield "python"
-    for ver in [(2,6), (2,7), (3,3), (3,4), (3,5), (3,6)]:
+    for ver in [(2,6), (2,7), (3,3), (3,4), (3,5), (3,6), (3,7)]:
         yield "python%d.%d" % ver
         if sys.platform == "win32":
             yield "python%d%d" % ver


### PR DESCRIPTION
All test cases succeeded in Python 3.7 without any warnings.
Therefore, I considered that `markdown2` supported Python 3.7
