### PR TITLE
Update tox envlist to follow currently supported Python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py24, py25, py26, py27, py32, py33, py34, py35, py36, pypy, jython
+envlist = py26, py27, py33, py34, py35, py36, py37, pypy, jython
 
 [testenv]
 commands = make testone


### PR DESCRIPTION
`tox.ini` included Python versions that already dropped, and not include a supporting version (`Python 3.7`).