### PR TITLE
Fix _toc_depth initialization: #311

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -236,8 +236,11 @@ class Markdown(object):
                 extras = dict([(e, None) for e in extras])
             self.extras.update(extras)
         assert isinstance(self.extras, dict)
-        if "toc" in self.extras and "header-ids" not in self.extras:
-            self.extras["header-ids"] = None   # "toc" implies "header-ids"
+
+        if "toc" in self.extras:
+            if "header-ids" not in self.extras:
+                self.extras["header-ids"] = None   # "toc" implies "header-ids"
+
             if self.extras["toc"] is None:
                 self._toc_depth = 6
             else:

--- a/test/tm-cases/toc_5.html
+++ b/test/tm-cases/toc_5.html
@@ -1,0 +1,13 @@
+<h1 id="fruit">Fruit</h1>
+
+<ul>
+<li>apples</li>
+<li>bananas</li>
+</ul>
+
+<h1 id="veggies">Veggies</h1>
+
+<ul>
+<li>carrots</li>
+<li>lettuce</li>
+</ul>

--- a/test/tm-cases/toc_5.opts
+++ b/test/tm-cases/toc_5.opts
@@ -1,0 +1,1 @@
+{"extras": ["toc", "header-ids"]}

--- a/test/tm-cases/toc_5.tags
+++ b/test/tm-cases/toc_5.tags
@@ -1,0 +1,1 @@
+toc extra

--- a/test/tm-cases/toc_5.text
+++ b/test/tm-cases/toc_5.text
@@ -1,0 +1,10 @@
+# Fruit
+
+- apples
+- bananas
+
+# Veggies
+
+- carrots
+- lettuce
+

--- a/test/tm-cases/toc_5.toc_html
+++ b/test/tm-cases/toc_5.toc_html
@@ -1,0 +1,4 @@
+<ul>
+  <li><a href="#fruit">Fruit</a></li>
+  <li><a href="#veggies">Veggies</a></li>
+</ul>


### PR DESCRIPTION
This PR fix issue #311 

`_toc_depth` initialization skipped if both `"toc"` and `"header-ids"` are specified to `extras`.
This will cause `AttributeError` in the later process.
