### PR TITLE
Un-smart-quote footnote back refs

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1981,6 +1981,13 @@ class Markdown(object):
         text = text.replace("...", "&#8230;")
         text = text.replace(" . . . ", "&#8230;")
         text = text.replace(". . .", "&#8230;")
+
+        # TODO: See issue #150
+        if "footnotes" in self.extras and "footnote-ref" in text:
+            # Quotes in the footnote back ref get converted to "smart" quotes
+            # Change them back here to ensure they work.
+            text = text.replace('class="footnote-ref&#8221;', 'class="footnote-ref"')
+
         return text
 
     _block_quote_base = r'''

--- a/test/tm-cases/footnotes_smarty-pants.html
+++ b/test/tm-cases/footnotes_smarty-pants.html
@@ -1,0 +1,14 @@
+<p>This is a para with a footnote.<sup class="footnote-ref" id="fnref-1"><a href="#fn-1">1</a></sup></p>
+
+<div class="footnotes">
+<hr />
+<ol>
+<li id="fn-1">
+<p>Here is the <em>body</em> of <span class="yo">the</span> footnote.</p>
+
+<div class="blah">And here is the second para of the footnote.</div>
+
+<p><a href="#fnref-1" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
+</li>
+</ol>
+</div>

--- a/test/tm-cases/footnotes_smarty-pants.opts
+++ b/test/tm-cases/footnotes_smarty-pants.opts
@@ -1,0 +1,1 @@
+{"extras": ["footnotes", "smarty-pants"]}

--- a/test/tm-cases/footnotes_smarty-pants.text
+++ b/test/tm-cases/footnotes_smarty-pants.text
@@ -1,0 +1,5 @@
+This is a para with a footnote.[^1]
+
+[^1]: Here is the <em>body</em> of <span class="yo">the</span> footnote.
+
+    <div class="blah">And here is the second para of the footnote.</div>


### PR DESCRIPTION
Refs #150 

I don't think this is a great solution to this problem, as clearly attributes in HTML should never be smart-quoted.

However, for this specific problem this patch is a fix.

I'd be happy to chat more about better ways of doing this and to work on a better fix. 