### PR TITLE
Stop XML escaping the body of a link.

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1408,7 +1408,7 @@ class Markdown(object):
                             result_head = '<a href="#"%s>' % (title_str)
                         else:
                             result_head = '<a href="%s"%s>' % (_html_escape_url(url, safe_mode=self.safe_mode), title_str)
-                        result = '%s%s</a>' % (result_head, _xml_escape_attr(link_text))
+                        result = '%s%s</a>' % (result_head, link_text)
                         if "smarty-pants" in self.extras:
                             result = result.replace('"', self._escape_table['"'])
                         # <img> allowed from curr_pos on, <a> from

--- a/test/tm-cases/inline_links.html
+++ b/test/tm-cases/inline_links.html
@@ -1,6 +1,8 @@
 <p>an inline <a href="/url/">link</a></p>
 
-<p>a <a href="/url/" title="title">link &quot;with&quot; title</a></p>
+<p>a <a href="/url/" title="title">link "with" title</a></p>
+
+<p>an inline <a href="/url/">link with <code>code</code></a></p>
 
 <p>an inline <img src="/url/" alt="image link" /></p>
 

--- a/test/tm-cases/inline_links.text
+++ b/test/tm-cases/inline_links.text
@@ -2,6 +2,8 @@ an inline [link](/url/)
 
 a [link "with" title](/url/ "title")
 
+an inline [link with `code`](/url/)
+
 an inline ![image link](/url/)
 
 an ![image "with" title](/url/ "title")

--- a/test/tm-cases/long_link.html
+++ b/test/tm-cases/long_link.html
@@ -1,12 +1,12 @@
 <h1>works</h1>
 
-<p><a href="http://tuxdeluxe.org/node/287">wever installation of Kunnafonix was resisted by many of the local organizations they had to work with The local &quot;computer person&quot; resented a solution that was so easy to use that it undermined the power and prestige they received by being the person to consult when a Windows computer had problems</a></p>
+<p><a href="http://tuxdeluxe.org/node/287">wever installation of Kunnafonix was resisted by many of the local organizations they had to work with The local "computer person" resented a solution that was so easy to use that it undermined the power and prestige they received by being the person to consult when a Windows computer had problems</a></p>
 
 <h1>issue 24: these fail</h1>
 
 <p><a href="http://tuxdeluxe.org/node/287">wever installation of Kunnafonix was resisted by many of the local organizations they had to 
-work with The local &quot;computer person&quot; resented a solution that was so easy to use that it undermined 
+work with The local "computer person" resented a solution that was so easy to use that it undermined 
 the power and prestige they received by being the person to consult when a Windows computer had 
 problems</a></p>
 
-<p><a href="http://tuxdeluxe.org/node/287">However installation of Kunnafonix was resisted by many of the local organizations they had to work with The local &quot;computer person&quot; resented a solution that was so easy to use that it undermined the power and prestige they received by being the person to consult when a Windows computer had problems</a></p>
+<p><a href="http://tuxdeluxe.org/node/287">However installation of Kunnafonix was resisted by many of the local organizations they had to work with The local "computer person" resented a solution that was so easy to use that it undermined the power and prestige they received by being the person to consult when a Windows computer had problems</a></p>


### PR DESCRIPTION
This was added as part of 000343d, but isn't necessary for that change,
and causes links like [`example`] to render as "&lt;code&gt...".

Fixes #259