### PR TITLE
Don't auto link patterns surrounded by """.

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1772,7 +1772,7 @@ class Markdown(object):
                 lexer_name = lexer_name[3:].strip()
                 codeblock = rest.lstrip("\n")   # Remove lexer declaration line.
                 formatter_opts = self.extras['code-color'] or {}
-        
+
         # Use pygments only if not using the highlightjs-lang extra
         if lexer_name and "highlightjs-lang" not in self.extras:
             def unhash_code(codeblock):
@@ -2146,7 +2146,7 @@ class Markdown(object):
     def _encode_incomplete_tags(self, text):
         if self.safe_mode not in ("replace", "escape"):
             return text
-            
+
         return self._incomplete_tags_re.sub("&lt;\\1", text)
 
     def _encode_backslash_escapes(self, text):
@@ -2216,6 +2216,11 @@ class Markdown(object):
 
                 # Do not match against links in the standard markdown syntax.
                 if text[start - 2:start] == '](' or text[end:end + 2] == '")':
+                    continue
+
+                # Do not match against links which are escaped.
+                if text[start - 3:start] == '"""' and text[end:end + 3] == '"""':
+                    text = text[:start - 3] + text[start:end] + text[end + 3:]
                     continue
 
                 escaped_href = (

--- a/test/tm-cases/link_patterns_escape.html
+++ b/test/tm-cases/link_patterns_escape.html
@@ -1,0 +1,9 @@
+<p>Recipe 123 and <a href="http://bugs.activestate.com/show_bug.cgi?id=234">a link to Komodo bug 234</a> are related.</p>
+
+<p><a href="http://example.org/Recipe 123">This is a link which has a pattern inside the url that shouldn't expand.</a></p>
+
+<p>Matched pattern is escaped: PEP 42 might be related too.</p>
+
+<p>Triple quotes not surrounding a matched pattern: PEP """42""" might be related too.</p>
+
+<p>"""This is some random text which should not be touched."""</p>

--- a/test/tm-cases/link_patterns_escape.opts
+++ b/test/tm-cases/link_patterns_escape.opts
@@ -1,0 +1,8 @@
+{"extras": ["link-patterns"],
+ "link_patterns": [
+    (re.compile("recipe\s+(\d+)", re.I), r"http://code.activestate.com/recipes/\1/"),
+    (re.compile("(?:komodo\s+)?bug\s+(\d+)", re.I), r"http://bugs.activestate.com/show_bug.cgi?id=\1"),
+    (re.compile("PEP\s+(\d+)", re.I), lambda m: "http://www.python.org/dev/peps/pep-%04d/" % int(m.group(1))),
+ ],
+}
+

--- a/test/tm-cases/link_patterns_escape.text
+++ b/test/tm-cases/link_patterns_escape.text
@@ -1,0 +1,9 @@
+"""Recipe 123""" and <a href="http://bugs.activestate.com/show_bug.cgi?id=234">a link to """Komodo bug 234"""</a> are related.
+
+<a href="http://example.org/"""Recipe 123"""">This is a link which has a pattern inside the url that shouldn't expand.</a>
+
+Matched pattern is escaped: """PEP 42""" might be related too.
+
+Triple quotes not surrounding a matched pattern: PEP """42""" might be related too.
+
+"""This is some random text which should not be touched."""


### PR DESCRIPTION
This allows the prevention of `[WikiWikiWeb](http://wiki.c2.com/?WikiWikiWeb)` being transformed to `<a href="http://wiki.c2.com/?&lt;a href=&quot;aw.cgi?page=WikiWikiWeb&quot;&gt;WikiWikiWeb&lt;/a&gt;">WikiWikiWeb</a>` when the pattern linker sees the second WikiCase word if the author surrounds it with triple quotes: so `[WikiWikiWeb](http://wiki.c2.com/?"""WikiWikiWeb""")` is now transformed to `<a href="http://wiki.c2.com/?WikiWikiWeb">WikiWikiWeb</a>`.

The function responsible, `_do_link_patterns()`, already checked for the cases that the pattern was inside square brackets, or was preceeded by `](` or suffixed by `")`, and skips expanding in these cases. This addition simply adds a check that the pattern is not surrounded by triple quotes; the triple quotes are stripped from the output.