### PR TITLE
Add class configurability to the enclosing tag.

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2073,7 +2073,7 @@ class Markdown(object):
 
                 # Wrap <p> tags.
                 graf = self._run_span_gamut(graf)
-                grafs.append("<p>" + graf.lstrip(" \t") + "</p>")
+                grafs.append("<p%s>" % self._html_class_str_from_tag('p') + graf.lstrip(" \t") + "</p>")
 
                 if cuddled_list:
                     grafs.append(cuddled_list)

--- a/test/tm-cases/html_classes.html
+++ b/test/tm-cases/html_classes.html
@@ -26,10 +26,10 @@
 </tbody>
 </table>
 
-<p>For example:</p>
+<p class="col-xs-3 custom-paragraph-class">For example:</p>
 
 <pre class="syntaxcolor"><code class="codesyntaxcolor">if cond:
     print doit()
 </code></pre>
 
-<p><img src="http://www.google.com/images/logo.gif" alt="the google logo" class="custom-image-class" /></p>
+<p class="col-xs-3 custom-paragraph-class"><img src="http://www.google.com/images/logo.gif" alt="the google logo" class="custom-image-class" /></p>

--- a/test/tm-cases/html_classes.opts
+++ b/test/tm-cases/html_classes.opts
@@ -6,7 +6,8 @@
       "pre": "syntaxcolor",
       "code": "codesyntaxcolor",
       "img": "custom-image-class",
-      "table": "table table-striped"
+      "table": "table table-striped",
+      "p": "col-xs-3 custom-paragraph-class",
     }
   }
 }

--- a/test/tm-cases/html_classes.tags
+++ b/test/tm-cases/html_classes.tags
@@ -1,1 +1,1 @@
-extras html-classes knownfailure code.as.com
+extras html-classes code.as.com


### PR DESCRIPTION
Adds support so you can customize the classes that decorate the enclosing `<p>` tags :)
Help for https://github.com/trentm/python-markdown2/issues/116