### PR TITLE
Accept [X] as marked task

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1655,7 +1655,7 @@ class Markdown(object):
         re.M | re.X | re.S)
 
     _task_list_item_re = re.compile(r'''
-        (\[[\ x]\])[ \t]+       # tasklist marker = \1
+        (\[[\ xX]\])[ \t]+       # tasklist marker = \1
         (.*)                   # list item text = \2
     ''', re.M | re.X | re.S)
 
@@ -1664,7 +1664,7 @@ class Markdown(object):
     def _task_list_item_sub(self, match):
         marker = match.group(1)
         item_text = match.group(2)
-        if marker == '[x]':
+        if marker in ['[x]','[X]']:
                 return self._task_list_warpper_str % ('checked ', item_text)
         elif marker == '[ ]':
                 return self._task_list_warpper_str % ('', item_text)

--- a/test/tm-cases/task_list.html
+++ b/test/tm-cases/task_list.html
@@ -1,4 +1,5 @@
 <ul>
 <li><input type="checkbox" class="task-list-item-checkbox" checked disabled> item1</li>
 <li><input type="checkbox" class="task-list-item-checkbox" disabled> item2</li>
+<li><input type="checkbox" class="task-list-item-checkbox" checked disabled> item3</li>
 </ul>

--- a/test/tm-cases/task_list.text
+++ b/test/tm-cases/task_list.text
@@ -1,2 +1,3 @@
 - [x] item1
 - [ ] item2
+- [X] item3


### PR DESCRIPTION
I'm a developer at @ccextractor and we will be using this project to send markdown to html emails in our CI system.

### The Issue
Github supports using either `[x]` or `[X]` in marking task list item. Unfortunately, markdown2 only converts `[x]` to checked list.

e.g.

- [x] this is marked
- [X] this is also marked
- [ ] this is not marked

### The Fix
I've changed the regex to accept [X] in the tasklist marked regex subgroup and consequently, we check using a conditional block.