### PR TITLE
Reset _toc when convert is run

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -202,6 +202,8 @@ class Markdown(object):
     html_spans = None
     html_removed_text = "[HTML_REMOVED]"  # for compat with markdown.py
 
+    _toc = None
+
     # Used to track when we're inside an ordered or unordered list
     # (see _ProcessListItems() for details):
     list_level = 0
@@ -273,6 +275,7 @@ class Markdown(object):
             self._count_from_header_id = defaultdict(int)
         if "metadata" in self.extras:
             self.metadata = {}
+        self._toc = None
 
     # Per <https://developer.mozilla.org/en-US/docs/HTML/Element/a> "rel"
     # should only be used in <a> tags with an "href" attribute.
@@ -1509,7 +1512,6 @@ class Markdown(object):
 
         return header_id
 
-    _toc = None
     def _toc_add_entry(self, level, id, name):
         if level > self._toc_depth:
             return

--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -291,6 +291,51 @@ versions of markdown2.py this was pathologically slow:</p>
             '<h2>%s</h2>\n' % ko)
     test_russian.tags = ["unicode", "issue3"]
 
+    def test_toc_with_persistent_object(self):
+        """
+        Tests that the toc is the same every time it's run on HTML, even if the Markdown object isn't disposed of.
+        """
+        md = markdown2.Markdown(extras=["toc"])
+        html = """
+# Header 1
+## Header 1.1
+## Header 1.2
+### Header 1.3
+# Header 2
+## Header 2.1
+        """
+        expected_toc_html = """<ul>
+  <li><a href="#header-1">Header 1</a>
+  <ul>
+    <li><a href="#header-11">Header 1.1</a></li>
+    <li><a href="#header-12">Header 1.2</a>
+    <ul>
+      <li><a href="#header-13">Header 1.3</a></li>
+    </ul></li>
+  </ul></li>
+  <li><a href="#header-2">Header 2</a>
+  <ul>
+    <li><a href="#header-21">Header 2.1</a></li>
+  </ul></li>
+</ul>
+"""
+        self.assertEqual(expected_toc_html, md.convert(html).toc_html)
+        # Do it again, to check if the toc_html is just appended rather than replaced
+        self.assertEqual(expected_toc_html, md.convert(html).toc_html)
+        # Create different html, and confirm toc_html is replaced
+        html = """
+# I'm new html
+## I don't have to be long, just different
+"""
+        expected_toc_html = """<ul>
+  <li><a href="#im-new-html">I'm new html</a>
+  <ul>
+    <li><a href="#i-dont-have-to-be-long-just-different">I don't have to be long, just different</a></li>
+  </ul></li>
+</ul>
+"""
+        self.assertEqual(expected_toc_html, md.convert(html).toc_html)
+
 
 class DocTestsTestCase(unittest.TestCase):
     def test_api(self):

--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -335,6 +335,7 @@ versions of markdown2.py this was pathologically slow:</p>
 </ul>
 """
         self.assertEqual(expected_toc_html, md.convert(html).toc_html)
+    test_toc_with_persistent_object.tags = ["toc", "issue208"]
 
 
 class DocTestsTestCase(unittest.TestCase):


### PR DESCRIPTION
Reset the _toc variable to None whenever a new conversion is performed.

Resolves #208