### PR TITLE
Version specific tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
   - "3.6"
   - "3.7-dev"
 # command to install dependencies
-install: pip install Pygments>=2.1.1
+install: pip install Pygments==2.4.2
 # command to run tests
 script: make testone

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
   - "3.6"
   - "3.7-dev"
 # command to install dependencies
-install: pip install Pygments==2.4.2
+install: pip install Pygments>=2.1.1
 # command to run tests
 script: make testone

--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -190,10 +190,8 @@ class _MarkdownTestCase(unittest.TestCase):
             if not exists(metadata_path):
                 metadata_path = None
 
-            test_func = lambda self, t=text_path, o=opts, c=toc_html_path, \
-                    m=metadata_path: \
-                    self._assertMarkdownPath(t, opts=o, toc_html_path=c,
-                          metadata_path=m)
+            def test_func(self, t=text_path, o=opts, c=toc_html_path, m=metadata_path):
+                self._assertMarkdownPath(t, opts=o, toc_html_path=c, metadata_path=m)
 
             tags_path = splitext(text_path)[0] + ".tags"
             if exists(tags_path):
@@ -202,6 +200,11 @@ class _MarkdownTestCase(unittest.TestCase):
                     if '#' in line: # allow comments in .tags files
                         line = line[:line.index('#')]
                     tags += line.split()
+                # If this is running in Python 3.4 and this test has a pygments tag, skip it
+                version_info = sys.version_info
+                if "pygments" in tags and version_info.major >= 3 and version_info.minor <= 4:
+                    print("Skipping pygments test in Python 3.4 or earlier")
+                    continue
                 test_func.tags = tags
 
             name = splitext(basename(text_path))[0]

--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -71,10 +71,12 @@ class _MarkdownTestCase(unittest.TestCase):
             %s""") % (close_though, _display(text),
                       _display(python_html), _display(perl_html)))
 
-    def _assertMarkdownPath(self, text_path, encoding="utf-8", opts=None,
-            toc_html_path=None, metadata_path=None):
+    def _assertMarkdownPath(self, text_path, encoding="utf-8", opts=None, toc_html_path=None, metadata_path=None):
         text = codecs.open(text_path, 'r', encoding=encoding).read()
-        html_path = splitext(text_path)[0] + ".html"
+        filename = splitext(text_path)[0]
+        html_path = "{}_{}.{}.html".format(filename, sys.version_info.major, sys.version_info.minor)
+        if not os.path.isfile(html_path):
+            html_path = filename + ".html"
         html = codecs.open(html_path, 'r', encoding=encoding).read()
         extra = {}
         if toc_html_path:
@@ -200,11 +202,6 @@ class _MarkdownTestCase(unittest.TestCase):
                     if '#' in line: # allow comments in .tags files
                         line = line[:line.index('#')]
                     tags += line.split()
-                # If this is running in Python 3.4 and this test has a pygments tag, skip it
-                version_info = sys.version_info
-                if "pygments" in tags and version_info.major >= 3 and version_info.minor <= 4:
-                    print("Skipping pygments test in Python 3.4 or earlier")
-                    continue
                 test_func.tags = tags
 
             name = splitext(basename(text_path))[0]

--- a/test/tm-cases/fenced_code_blocks_leading_lang_space.html
+++ b/test/tm-cases/fenced_code_blocks_leading_lang_space.html
@@ -1,3 +1,3 @@
-<div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
-    <span class="k">print</span> <span class="s2">&quot;hi&quot;</span>
+<div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+    <span class="nb">print</span> <span class="s2">&quot;hi&quot;</span>
 </code></pre></div>

--- a/test/tm-cases/fenced_code_blocks_leading_lang_space.tags
+++ b/test/tm-cases/fenced_code_blocks_leading_lang_space.tags
@@ -1,1 +1,1 @@
-extra fenced-code-blocks pygments knownfailure issue338
+extra fenced-code-blocks pygments issue338

--- a/test/tm-cases/fenced_code_blocks_leading_lang_space.tags
+++ b/test/tm-cases/fenced_code_blocks_leading_lang_space.tags
@@ -1,1 +1,1 @@
-extra fenced-code-blocks pygments
+extra fenced-code-blocks pygments knownfailure issue338

--- a/test/tm-cases/fenced_code_blocks_leading_lang_space_3.4.html
+++ b/test/tm-cases/fenced_code_blocks_leading_lang_space_3.4.html
@@ -1,0 +1,3 @@
+<div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="k">print</span> <span class="s2">&quot;hi&quot;</span>
+</code></pre></div>

--- a/test/tm-cases/fenced_code_blocks_safe_highlight.html
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight.html
@@ -1,5 +1,5 @@
-<div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
-    <span class="k">print</span> <span class="s2">&quot;hi&quot;</span>
+<div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+    <span class="nb">print</span> <span class="s2">&quot;hi&quot;</span>
 </code></pre></div>
 
 <p>That's using the <em>fenced-code-blocks</em> extra with Python

--- a/test/tm-cases/fenced_code_blocks_safe_highlight.tags
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight.tags
@@ -1,1 +1,1 @@
-extra fenced-code-blocks pygments knownfailure issue338
+extra fenced-code-blocks pygments issue338

--- a/test/tm-cases/fenced_code_blocks_safe_highlight.tags
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight.tags
@@ -1,1 +1,1 @@
-extra fenced-code-blocks pygments
+extra fenced-code-blocks pygments knownfailure issue338

--- a/test/tm-cases/fenced_code_blocks_safe_highlight_3.4.html
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight_3.4.html
@@ -1,0 +1,12 @@
+<div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="k">print</span> <span class="s2">&quot;hi&quot;</span>
+</code></pre></div>
+
+<p>That's using the <em>fenced-code-blocks</em> extra with Python
+syntax coloring, if <code>pygments</code> is installed. See
+<a href="http://github.github.com/github-flavored-markdown/">http://github.github.com/github-flavored-markdown/</a>.</p>
+
+<div class="codehilite"><pre><span></span><code><span class="k">def</span> <span class="nf">foo</span>
+    <span class="nb">puts</span> <span class="s2">&quot;hi&quot;</span>
+<span class="k">end</span>
+</code></pre></div>

--- a/test/tm-cases/fenced_code_blocks_syntax_highlighting.html
+++ b/test/tm-cases/fenced_code_blocks_syntax_highlighting.html
@@ -1,5 +1,5 @@
-<div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
-    <span class="k">print</span> <span class="s2">&quot;hi&quot;</span>
+<div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+    <span class="nb">print</span> <span class="s2">&quot;hi&quot;</span>
 </code></pre></div>
 
 <p>That's using the <em>fenced-code-blocks</em> extra with Python

--- a/test/tm-cases/fenced_code_blocks_syntax_highlighting.tags
+++ b/test/tm-cases/fenced_code_blocks_syntax_highlighting.tags
@@ -1,1 +1,1 @@
-extra fenced-code-blocks pygments knownfailure issue338
+extra fenced-code-blocks pygments issue338

--- a/test/tm-cases/fenced_code_blocks_syntax_highlighting.tags
+++ b/test/tm-cases/fenced_code_blocks_syntax_highlighting.tags
@@ -1,1 +1,1 @@
-extra fenced-code-blocks pygments
+extra fenced-code-blocks pygments knownfailure issue338

--- a/test/tm-cases/fenced_code_blocks_syntax_highlighting_3.4.html
+++ b/test/tm-cases/fenced_code_blocks_syntax_highlighting_3.4.html
@@ -1,0 +1,12 @@
+<div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="k">print</span> <span class="s2">&quot;hi&quot;</span>
+</code></pre></div>
+
+<p>That's using the <em>fenced-code-blocks</em> extra with Python
+syntax coloring, if <code>pygments</code> is installed. See
+<a href="http://github.github.com/github-flavored-markdown/">http://github.github.com/github-flavored-markdown/</a>.</p>
+
+<div class="codehilite"><pre><span></span><code><span class="k">def</span> <span class="nf">foo</span>
+    <span class="nb">puts</span> <span class="s2">&quot;hi&quot;</span>
+<span class="k">end</span>
+</code></pre></div>

--- a/test/tm-cases/fenced_code_blocks_syntax_indentation.html
+++ b/test/tm-cases/fenced_code_blocks_syntax_indentation.html
@@ -1,5 +1,5 @@
 <div class="codehilite"><pre><span></span><code><span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>
-    <span class="k">print</span> <span class="s2">&quot;foo&quot;</span>
+    <span class="nb">print</span> <span class="s2">&quot;foo&quot;</span>
 
-    <span class="k">print</span> <span class="s2">&quot;bar&quot;</span>
+    <span class="nb">print</span> <span class="s2">&quot;bar&quot;</span>
 </code></pre></div>

--- a/test/tm-cases/fenced_code_blocks_syntax_indentation.tags
+++ b/test/tm-cases/fenced_code_blocks_syntax_indentation.tags
@@ -1,1 +1,1 @@
-extra fenced-code-blocks pygments indentation knownfailure issue338
+extra fenced-code-blocks pygments indentation issue338

--- a/test/tm-cases/fenced_code_blocks_syntax_indentation.tags
+++ b/test/tm-cases/fenced_code_blocks_syntax_indentation.tags
@@ -1,1 +1,1 @@
-extra fenced-code-blocks pygments indentation
+extra fenced-code-blocks pygments indentation knownfailure issue338

--- a/test/tm-cases/fenced_code_blocks_syntax_indentation_3.4.html
+++ b/test/tm-cases/fenced_code_blocks_syntax_indentation_3.4.html
@@ -1,0 +1,5 @@
+<div class="codehilite"><pre><span></span><code><span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>
+    <span class="k">print</span> <span class="s2">&quot;foo&quot;</span>
+
+    <span class="k">print</span> <span class="s2">&quot;bar&quot;</span>
+</code></pre></div>

--- a/test/tm-cases/issue3_bad_code_color_hack.html
+++ b/test/tm-cases/issue3_bad_code_color_hack.html
@@ -7,6 +7,6 @@
 <p>Some python code:</p>
 
 <div class="codehilite"><pre><span></span><code><span class="c1"># комментарий</span>
-<span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
-    <span class="k">print</span> <span class="s2">&quot;hi&quot;</span>
+<span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+    <span class="nb">print</span> <span class="s2">&quot;hi&quot;</span>
 </code></pre></div>

--- a/test/tm-cases/issue3_bad_code_color_hack.tags
+++ b/test/tm-cases/issue3_bad_code_color_hack.tags
@@ -1,1 +1,1 @@
-extra code-color unicode pygments issue3
+extra code-color unicode pygments issue3 knownfailure issue338

--- a/test/tm-cases/issue3_bad_code_color_hack.tags
+++ b/test/tm-cases/issue3_bad_code_color_hack.tags
@@ -1,1 +1,1 @@
-extra code-color unicode pygments issue3 knownfailure issue338
+extra code-color unicode pygments issue3 issue338

--- a/test/tm-cases/issue3_bad_code_color_hack_3.4.html
+++ b/test/tm-cases/issue3_bad_code_color_hack_3.4.html
@@ -1,0 +1,12 @@
+<!-- -*- coding: utf-8 -*- -->
+
+<h2>заголовок</h2>
+
+<p>Example from <a href="http://code.google.com/p/python-markdown2/issues/detail?id=3#c8">http://code.google.com/p/python-markdown2/issues/detail?id=3#c8</a>.</p>
+
+<p>Some python code:</p>
+
+<div class="codehilite"><pre><span></span><code><span class="c1"># комментарий</span>
+<span class="k">if</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="k">print</span> <span class="s2">&quot;hi&quot;</span>
+</code></pre></div>


### PR DESCRIPTION
As an alternative to blocking some tests in Python 3.4, allow for alternate HTML output files depending on the Python version.