### PR TITLE
Add non latin charset support for 'header-ids'

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2345,7 +2345,8 @@ def _slugify(value, non_latin_mode=False):
     """
     import unicodedata
     if non_latin_mode:
-        from transliterate import translit, LanguageDetectionError
+        from transliterate import translit 
+        from transliterate.exceptions import LanguageDetectionError
         try:
             value = translit(value, revesed=True)
         except LanguageDetectionError:

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2348,7 +2348,7 @@ def _slugify(value, non_latin_mode=False):
         from transliterate import translit 
         from transliterate.exceptions import LanguageDetectionError
         try:
-            value = translit(value, revesed=True)
+            value = translit(value, reversed=True)
         except LanguageDetectionError:
             pass
     value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode()


### PR DESCRIPTION
# What it do?
Simple translit non latin text into latin text and create correct id.
Right, it's need, optional depends, [transliterate](https://github.com/barseghyanartur/transliterate)

# Example
We see, what we get correct id, but only on `# Header`, `# Заголовок` get incorrect id.  
![image](https://user-images.githubusercontent.com/52283674/79192043-ca4d5700-7e49-11ea-9b19-0fad9bf302df.png)
Then, we simple can add a parameter `non_latin_mode`
![image](https://user-images.githubusercontent.com/52283674/79192261-329c3880-7e4a-11ea-8b44-cd59067caee7.png)
And it's not broke a latin text and converted non latin.
 