### PR TITLE
Tables: use style=text-align for table alignment

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1013,11 +1013,11 @@ class Markdown(object):
         align_from_col_idx = {}
         for col_idx, col in enumerate(cols):
             if col[0] == ':' and col[-1] == ':':
-                align_from_col_idx[col_idx] = ' align="center"'
+                align_from_col_idx[col_idx] = ' style="text-align:center;"'
             elif col[0] == ':':
-                align_from_col_idx[col_idx] = ' align="left"'
+                align_from_col_idx[col_idx] = ' style="text-align:left;"'
             elif col[-1] == ':':
-                align_from_col_idx[col_idx] = ' align="right"'
+                align_from_col_idx[col_idx] = ' style="text-align:right;"'
 
         # thead
         hlines = ['<table%s>' % self._html_class_str_from_tag('table'), '<thead>', '<tr>']

--- a/test/php-markdown-extra-cases/Tables.html
+++ b/test/php-markdown-extra-cases/Tables.html
@@ -133,56 +133,56 @@
 
 <hr />
 
-<p>Table alignement:</p>
+<p>Table alignment:</p>
 
 <table>
 <thead>
 <tr>
   <th>Default</th>
-  <th align="left">Right</th>
-  <th align="center">Center</th>
-  <th align="right">Left</th>
+  <th style="text-align:left;">Left</th>
+  <th style="text-align:center;">Center</th>
+  <th style="text-align:right;">Right</th>
 </tr>
 </thead>
 <tbody>
 <tr>
   <td>Long Cell</td>
-  <td align="left">Long Cell</td>
-  <td align="center">Long Cell</td>
-  <td align="right">Long Cell</td>
+  <td style="text-align:left;">Long Cell</td>
+  <td style="text-align:center;">Long Cell</td>
+  <td style="text-align:right;">Long Cell</td>
 </tr>
 <tr>
   <td>Cell</td>
-  <td align="left">Cell</td>
-  <td align="center">Cell</td>
-  <td align="right">Cell</td>
+  <td style="text-align:left;">Cell</td>
+  <td style="text-align:center;">Cell</td>
+  <td style="text-align:right;">Cell</td>
 </tr>
 </tbody>
 </table>
 
-<p>Table alignement (alternate spacing):</p>
+<p>Table alignment (alternate spacing):</p>
 
 <table>
 <thead>
 <tr>
   <th>Default</th>
-  <th align="left">Right</th>
-  <th align="center">Center</th>
-  <th align="right">Left</th>
+  <th style="text-align:left;">Left</th>
+  <th style="text-align:center;">Center</th>
+  <th style="text-align:right;">Right</th>
 </tr>
 </thead>
 <tbody>
 <tr>
   <td>Long Cell</td>
-  <td align="left">Long Cell</td>
-  <td align="center">Long Cell</td>
-  <td align="right">Long Cell</td>
+  <td style="text-align:left;">Long Cell</td>
+  <td style="text-align:center;">Long Cell</td>
+  <td style="text-align:right;">Long Cell</td>
 </tr>
 <tr>
   <td>Cell</td>
-  <td align="left">Cell</td>
-  <td align="center">Cell</td>
-  <td align="right">Cell</td>
+  <td style="text-align:left;">Cell</td>
+  <td style="text-align:center;">Cell</td>
+  <td style="text-align:right;">Cell</td>
 </tr>
 </tbody>
 </table>

--- a/test/php-markdown-extra-cases/Tables.text
+++ b/test/php-markdown-extra-cases/Tables.text
@@ -50,19 +50,19 @@ With leading and tailing pipes:
 
 * * *
 
-Table alignement:
+Table alignment:
 
-| Default   | Right     |  Center   |     Left  |
+| Default   | Left      |  Center   |     Right |
 | --------- |:--------- |:---------:| ---------:|
 | Long Cell | Long Cell | Long Cell | Long Cell |
-| Cell      | Cell      |   Cell    |     Cell  |
+| Cell      | Cell      |   Cell    |      Cell |
 
-Table alignement (alternate spacing):
+Table alignment (alternate spacing):
 
-| Default   | Right     |  Center   |     Left  |
+| Default   | Left      |  Center   |     Right |
 | --------- | :-------- | :-------: | --------: |
 | Long Cell | Long Cell | Long Cell | Long Cell |
-| Cell      | Cell      |   Cell    |     Cell  |
+| Cell      | Cell      |   Cell    |      Cell |
 
 * * * 
 


### PR DESCRIPTION
Table alignment currently uses `align=left|center|right` which is a deprecated attribute with limited support in modern browsers.

At the moment I'm having to post-process the Markdown generated by markdown2.py in order to replace the aligns with text-align as we need good cross-browser support (notably, Firefox completely ignores the `align` attribute).

See:
* https://caniuse.com/#feat=mdn-html_elements_th_align
* https://caniuse.com/#feat=mdn-html_elements_td_align

This PR switches instead to the recommended and more widely-supported `style=text-align`: https://caniuse.com/#feat=mdn-css_properties_text-align

Additionally, in updating the tests I found that they contained a spelling error and that they have their lefts and rights switched (I double-checked the expected output for the syntax on https://help.github.com/en/github/writing-on-github/organizing-information-with-tables ).

I know the `extras` tests are imported from an upstream repo, so I'm not sure how you would prefer to handle this inconsistency, but I thought it was sufficiently confusing to have it read "left" when it expected "right" that it was worth updating.