### PR TITLE
Support for structured and nested values in metadata (#120)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -475,7 +475,6 @@ class Markdown(object):
             tail = metadata_split[1]
 
         def parse_structured_value(value):
-            print(repr(value))
             vs = value.lstrip()
             vs = value.replace(v[: len(value) - len(vs)], "\n")[1:]
 

--- a/test/tm-cases/metadata.metadata
+++ b/test/tm-cases/metadata.metadata
@@ -5,5 +5,7 @@
   "this-is": "a hyphen test",
   "empty": "",
   "and some": "long value\n that goes multiline",
-  "another": "example"
+  "another": "example",
+  "alist": ["a", "b", "c"],
+  "adict": {"key": "foo", "a nested list": ["one", "two", "Even multiline strings are allowed\n  in nested structured data\n  if linebreaks and indent are respected !", {"subkey": "and another dict in a list"}]}
 }

--- a/test/tm-cases/metadata.text
+++ b/test/tm-cases/metadata.text
@@ -8,6 +8,21 @@ and some: >
  long value
  that goes multiline
 another: example
+alist:
+  - a
+  - b
+  - c
+adict:
+  key: foo
+  a nested list:
+    - one
+    - two
+    - >
+      Even multiline strings are allowed
+      in nested structured data
+      if linebreaks and indent are respected !
+    -
+      subkey: and another dict in a list
 ---
 # The real text
 


### PR DESCRIPTION
Pull request fixing #120. All tests passes. Existing test on metadata is extended to cover new cases.

### Dict support

```yaml
key:
  subkey: subvalue
```
is now parsed as `key: {subkey: subvalue}`

### List support

```yaml
key:
  - one
  - two
```
is now parsed as `key: ["one", "two"]`

### Nested structured values support

```yaml
key:
  subkey:
    - >
      Long text
      in structure
```
is now parsed as `key: {subkey: ["Long text\n  in structure"]`

### Nota bene

- Sub-elements can be indented by an arbitrary number of spaces or tabs, as soon as the indent is strictly identical for each element.
- Sub-elements must begin with a line return. syntax like `key: subkey: subvalue` is not supported.