### PR TITLE
Add support for Python 3.8-3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 # command to install dependencies
 install: pip install Pygments>=2.5.2
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - "pypy3"
   - "3.5"

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     package_dir={"": "lib"},
     scripts=[script],
     description="A fast and complete Python implementation of Markdown",
+    python_requires=">=2.6, !=3.0.*, !=3.1.*, !=3.2.*",
     classifiers=filter(None, classifiers.split("\n")),
     long_description="""markdown2: A fast and complete Python implementation of Markdown.
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     scripts=[script],
     description="A fast and complete Python implementation of Markdown",
     python_requires=">=2.6, !=3.0.*, !=3.1.*, !=3.2.*",
-    classifiers=filter(None, classifiers.split("\n")),
+    classifiers=classifiers.strip().split("\n"),
     long_description="""markdown2: A fast and complete Python implementation of Markdown.
 
 Markdown is a text-to-HTML filter; it translates an easy-to-read /

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
 Operating System :: OS Independent
 Topic :: Software Development :: Libraries :: Python Modules
 Topic :: Software Development :: Documentation


### PR DESCRIPTION
`3.9` isn't yet on Travis CI (give [this](https://travis-ci.community/t/python-3-9-0-build/10091?u=hugovk) a +1), `3.9-dev` is good for now.

Update Trove classifiers for 3.8 and 3.9.

Add `python_requires` to help pip.

And fix `Warning: 'classifiers' should be a list, got type 'filter'"` when running `python setup.py --classifiers` (or any `--help` or any option).