### PR TITLE
Fixed bug breaking strings elements in metadata lists

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -452,7 +452,7 @@ class Markdown(object):
         r"(.*:\s+>\n\s+[\S\s]+?)(?=\n\w+\s*:\s*\w+\n|\Z)", re.MULTILINE
     )
     _key_val_list_pat = re.compile(
-        r"^-(?:[ \t]*([^:\s]*)(?:[ \t]*[:-][ \t]*(\S+))?)(?:\n((?:[ \t]+[^\n]+\n?)+))?",
+        r"^-(?:[ \t]*([^\n]*)(?:[ \t]*[:-][ \t]*(\S+))?)(?:\n((?:[ \t]+[^\n]+\n?)+))?",
         re.MULTILINE,
     )
     _key_val_dict_pat = re.compile(

--- a/test/tm-cases/metadata.metadata
+++ b/test/tm-cases/metadata.metadata
@@ -7,5 +7,5 @@
   "and some": "long value\n that goes multiline",
   "another": "example",
   "alist": ["a", "b", "c"],
-  "adict": {"key": "foo", "a nested list": ["one", "two", "Even multiline strings are allowed\n  in nested structured data\n  if linebreaks and indent are respected !", {"subkey": "and another dict in a list"}]}
+  "adict": {"key": "foo", "a nested list": ["one", "two", "Even multiline strings are allowed\n  in nested structured data\n  if linebreaks and indent are respected !", {"subkey": "and another dict in a list"}, "but one-liners remains: simple strings"]}
 }

--- a/test/tm-cases/metadata.text
+++ b/test/tm-cases/metadata.text
@@ -23,6 +23,7 @@ adict:
       if linebreaks and indent are respected !
     -
       subkey: and another dict in a list
+    - but one-liners remains: simple strings
 ---
 # The real text
 


### PR DESCRIPTION
Pull request fixing a bug I just discovered in the structured metadata feature I introduced in #368.

In metadata lists, strings elements were cut at the first space or `:` symbol encountered, instead of being kept completely as a string element.

I fixed the regex used to catch list elements and updated the test scenario to cover this case.