### PR TITLE
Fix backslash deprecation warnings

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2232,7 +2232,7 @@ class Markdown(object):
         text = self._naked_gt_re.sub('&gt;', text)
         return text
 
-    _incomplete_tags_re = re.compile("<(/?\w+?(?!\w).+?[\s/]+?)")
+    _incomplete_tags_re = re.compile(r"<(/?\w+?(?!\w).+?[\s/]+?)")
 
     def _encode_incomplete_tags(self, text):
         if self.safe_mode not in ("replace", "escape"):

--- a/test/testall.py
+++ b/test/testall.py
@@ -20,7 +20,7 @@ def _python_ver_from_python(python):
     assert ' ' not in python
     o = os.popen('''%s -c "import sys; print(sys.version)"''' % python)
     ver_str = o.read().strip()
-    ver_bits = re.split("\.|[^\d]", ver_str, 2)[:2]
+    ver_bits = re.split(r"\.|[^\d]", ver_str, 2)[:2]
     ver = tuple(map(int, ver_bits))
     return ver
 


### PR DESCRIPTION
Addresses two of the three warnings given in #343.  The third one was fixed as [part of a7da039c081a](https://github.com/trentm/python-markdown2/commit/a7da039c081aaeb7c6eb18bba0ab0d76661a2b39#diff-59161098c0c2d506b5700112a54eb00354b867f46fa501a9f68cd86d843f1b57L449).

Running `make test` gives 6 errors for me.  All of them look like minor changes in Pygments output.