### PR TITLE
docs: fix simple typo, becase -> because

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -113,7 +113,7 @@ def tag(*tags):
 #---- timedtest decorator
 # Use this to assert that a test completes in a given amount of time.
 # This is from http://www.artima.com/forums/flat.jsp?forum=122&thread=129497
-# Including here, becase it might be useful.
+# Including here, because it might be useful.
 # NOTE: Untested and I suspect some breakage.
 
 TOLERANCE = 0.05


### PR DESCRIPTION
There is a small typo in test/testlib.py.

Should read `because` rather than `becase`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md