### PR TITLE
Tables extra: allow whitespace at the end of the underline row

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1113,10 +1113,10 @@ class Markdown(object):
                 ^[ ]{0,%d}                      # allowed whitespace
                 (                               # $2: underline row
                     # underline row with leading bar
-                    (?:  \|\ *:?-+:?\ *  )+  \|?  \n
+                    (?:  \|\ *:?-+:?\ *  )+  \|? \s? \n
                     |
                     # or, underline row without leading bar
-                    (?:  \ *:?-+:?\ *\|  )+  (?:  \ *:?-+:?\ *  )?  \n
+                    (?:  \ *:?-+:?\ *\|  )+  (?:  \ *:?-+:?\ *  )? \s? \n
                 )
 
                 (                               # $3: data rows

--- a/test/php-markdown-extra-cases/Tables.html
+++ b/test/php-markdown-extra-cases/Tables.html
@@ -308,3 +308,24 @@
 </tr>
 </tbody>
 </table>
+
+<h1>With a space at the end of the underline row</h1>
+
+<table>
+<thead>
+<tr>
+  <th>Header 1</th>
+  <th>Header 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>Cell 1</td>
+  <td>Cell 2</td>
+</tr>
+<tr>
+  <td>Cell 3</td>
+  <td>Cell 4</td>
+</tr>
+</tbody>
+</table>

--- a/test/php-markdown-extra-cases/Tables.text
+++ b/test/php-markdown-extra-cases/Tables.text
@@ -101,3 +101,10 @@ Header 1  | Header 2  |
 --------- | --------- |
 Cell      | Cell      |
 Cell      | Cell      
+
+# With a space at the end of the underline row
+
+Header 1  | Header 2  |
+--------- | --------- | 
+Cell 1    | Cell 2    |
+Cell 3    | Cell 4    |


### PR DESCRIPTION
This tiny regex adjustment fixes https://github.com/trentm/python-markdown2/issues/325

I also added a test case that passes (fails before this patch).

`python test.py` has 15 failures for me, with or without this change.