### PR TITLE
pyshell: add syntax highlighting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## python-markdown2 2.4.1 (not yet released)
 
 - [pull #389] Tables extra: allow whitespace at the end of the underline row
+- [pull #392] Pyshell extra: enable syntax highlighting if `fenced-code-blocks` is loaded.
 
 
 ## python-markdown2 2.4.0

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1029,6 +1029,9 @@ class Markdown(object):
         return text
 
     def _pyshell_block_sub(self, match):
+        if "fenced-code-blocks" in self.extras:
+            dedented = _dedent(match.group(0))
+            return self._do_fenced_code_blocks("```pycon\n" + dedented + "```\n")
         lines = match.group(0).splitlines(0)
         _dedentlines(lines)
         indent = ' ' * self.tab_width

--- a/test/tm-cases/pyshell_and_fenced_code_blocks.html
+++ b/test/tm-cases/pyshell_and_fenced_code_blocks.html
@@ -1,0 +1,21 @@
+<h1>From Recipe 302035</h1>
+
+<p>Some examples:</p>
+
+<div class="codehilite"><pre><span></span><code><span class="gp">&gt;&gt;&gt; </span><span class="n">nprint</span><span class="p">(</span><span class="mi">9876543210</span><span class="p">)</span>
+<span class="go">&#39;9 876 543 210&#39;</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">nprint</span><span class="p">(</span><span class="mi">987654321</span><span class="p">,</span> <span class="n">period</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">delimiter</span><span class="o">=</span><span class="s2">&quot;,&quot;</span><span class="p">)</span>
+<span class="go">&#39;9,8,7,6,5,4,3,2,1,0&#39;</span>
+</code></pre></div>
+
+<p>Indented a bit:</p>
+
+<div class="codehilite"><pre><span></span><code><span class="gp">&gt;&gt;&gt; </span><span class="mi">1</span> <span class="o">+</span> <span class="mi">1</span>
+<span class="go">2</span>
+</code></pre></div>
+
+<p>Cuddled to previous para (and at end of document):</p>
+
+<div class="codehilite"><pre><span></span><code><span class="gp">&gt;&gt;&gt; </span><span class="mi">2</span> <span class="o">+</span> <span class="mi">2</span>
+<span class="go">4</span>
+</code></pre></div>

--- a/test/tm-cases/pyshell_and_fenced_code_blocks.opts
+++ b/test/tm-cases/pyshell_and_fenced_code_blocks.opts
@@ -1,0 +1,1 @@
+{"extras": ["pyshell", "fenced-code-blocks"]}

--- a/test/tm-cases/pyshell_and_fenced_code_blocks.tags
+++ b/test/tm-cases/pyshell_and_fenced_code_blocks.tags
@@ -1,0 +1,1 @@
+extra fenced-code-blocks pygments pyshell

--- a/test/tm-cases/pyshell_and_fenced_code_blocks.text
+++ b/test/tm-cases/pyshell_and_fenced_code_blocks.text
@@ -1,0 +1,17 @@
+# From Recipe 302035
+
+Some examples:
+
+>>> nprint(9876543210)
+'9 876 543 210'
+>>> nprint(987654321, period=1, delimiter=",")
+'9,8,7,6,5,4,3,2,1,0'
+
+Indented a bit:
+
+ >>> 1 + 1
+ 2
+
+Cuddled to previous para (and at end of document):
+>>> 2 + 2
+4


### PR DESCRIPTION
First of all, thanks for the fantastic project! We're very happily using it for [pdoc](https://pdoc.dev/). 😃 

This PR changes the behavior of the pyshell extra to rely on fenced-code-blocks for syntax highlighting if both extras are enabled. pygments has a [matching lexer](https://pygments.org/docs/lexers/#pygments.lexers.python.PythonConsoleLexer) for those ">>>" blocks, which makes the implementation quite straightforward.