### PR TITLE
Travis CI: Upgrade to Python 3.10-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
+  - "3.10-dev"
 # command to install dependencies
 install: pip install Pygments>=2.5.2
 # command to run tests


### PR DESCRIPTION
Currently, Python 3.10.0a5+ on Travis CI but 3.10.0alpha6 is released
https://www.python.org/downloads/release/python-3100a6/