### PR TITLE
Fix alt text formatting in images

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1485,7 +1485,9 @@ class Markdown(object):
                         img_class_str = self._html_class_str_from_tag("img")
                         result = '<img src="%s" alt="%s"%s%s%s' \
                             % (_html_escape_url(url, safe_mode=self.safe_mode),
-                               _xml_escape_attr(link_text),
+                               _xml_escape_attr(link_text)
+                                .replace('*', self._escape_table['*'])
+                                .replace('_', self._escape_table['_']),
                                title_str,
                                img_class_str,
                                self.empty_element_suffix)
@@ -1541,7 +1543,9 @@ class Markdown(object):
                             img_class_str = self._html_class_str_from_tag("img")
                             result = '<img src="%s" alt="%s"%s%s%s' \
                                 % (_html_escape_url(url, safe_mode=self.safe_mode),
-                                   _xml_escape_attr(link_text),
+                                   _xml_escape_attr(link_text)
+                                    .replace('*', self._escape_table['*'])
+                                    .replace('_', self._escape_table['_']),
                                    title_str,
                                    img_class_str,
                                    self.empty_element_suffix)


### PR DESCRIPTION
If the markdown has link text with underscores, it gets changed to `<em>` tag.

For example a text like,

```
![Image hello_world_1.jpg](https://domain/hello_world_1.jpg)
```
currently gets converted to,
```
<p><img src="https://domain/hello_world_1.jpg" alt="Image hello<em>world</em>1.jpg" /></p>

```
We need to escape the `_` and `*` from alt text.