### PR TITLE
Fix meta indentation

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -516,7 +516,7 @@ class Markdown(object):
 
             # Multiline value
             if v[:3] == " >\n":
-                self.metadata[k.strip()] = v[3:].strip()
+                self.metadata[k.strip()] = _dedent(v[3:]).strip()
 
             # Empty value
             elif v == "\n":

--- a/test/tm-cases/metadata.metadata
+++ b/test/tm-cases/metadata.metadata
@@ -4,7 +4,7 @@
   "And": "some, cvs, data, which, you, must, parse, yourself",
   "this-is": "a hyphen test",
   "empty": "",
-  "and some": "long value\n that goes multiline",
+  "and some": "long value\n  with complex indentation\nthat goes multiline",
   "another": "example",
   "alist": ["a", "b", "c"],
   "adict": {"key": "foo", "a nested list": ["one", "two", "Even multiline strings are allowed\n  in nested structured data\n  if linebreaks and indent are respected !", {"subkey": "and another dict in a list"}, "but one-liners remains: simple strings"]}

--- a/test/tm-cases/metadata.text
+++ b/test/tm-cases/metadata.text
@@ -6,6 +6,7 @@ this-is : a hyphen test
 empty   :
 and some: >
  long value
+   with complex indentation
  that goes multiline
 another: example
 alist:

--- a/test/tm-cases/metadata2.metadata
+++ b/test/tm-cases/metadata2.metadata
@@ -4,6 +4,6 @@
   "And": "some, cvs, data, which, you, must, parse, yourself",
   "this-is": "a hyphen test",
   "empty": "",
-  "another long": "long value\n  that goes multiline",
+  "another long": "long value\n with complex indentation\nthat goes multiline",
   "another": "example"
 }

--- a/test/tm-cases/metadata2.text
+++ b/test/tm-cases/metadata2.text
@@ -5,6 +5,7 @@ this-is : a hyphen test
 empty   :
 another long: >
   long value
+   with complex indentation
   that goes multiline
 another: example
 


### PR DESCRIPTION
When processing a multiline meta value like this:
```
another long: >
  long value
   with complex indentation
  that goes multiline
```
The meta value for the "another long" key should look like:
```
long value
 with complex indentation
that goes multiline
```
Instead this:
```
long value
   with complex indentation
  that goes multiline
```

Tested using:
```
cd test
PYTHONPATH=../lib python test.py -- -knownfailure
```