### PR TITLE
Fix code surrounded by blank lines inside blockquote fenced code blocks

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1922,7 +1922,7 @@ class Markdown(object):
             ((?=^[ ]{0,%d}\S)|\Z)   # Lookahead for non-space at line-start, or end of doc
             # Lookahead to make sure this block isn't already in a code block.
             # Needed when syntax highlighting is being used.
-            (?![^<]*\</code\>)
+            (?!([^<]|<(/?)span)*\</code\>)
             ''' % (self.tab_width, self.tab_width),
             re.M | re.X)
         return code_block_re.sub(self._code_block_sub, text)

--- a/test/tm-cases/quoted_fenced_code_blocks_whitespace_around_indented_lines.html
+++ b/test/tm-cases/quoted_fenced_code_blocks_whitespace_around_indented_lines.html
@@ -1,0 +1,13 @@
+<h3>Example:</h3>
+
+<blockquote>
+  <div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+    <span class="nb">print</span><span class="p">()</span>
+
+    <span class="nb">print</span><span class="p">()</span>
+
+    <span class="nb">print</span><span class="p">()</span>
+
+    <span class="nb">print</span><span class="p">()</span>
+</code></pre></div>
+</blockquote>

--- a/test/tm-cases/quoted_fenced_code_blocks_whitespace_around_indented_lines.opts
+++ b/test/tm-cases/quoted_fenced_code_blocks_whitespace_around_indented_lines.opts
@@ -1,0 +1,1 @@
+{"extras": ["fenced-code-blocks"]}

--- a/test/tm-cases/quoted_fenced_code_blocks_whitespace_around_indented_lines.tags
+++ b/test/tm-cases/quoted_fenced_code_blocks_whitespace_around_indented_lines.tags
@@ -1,0 +1,1 @@
+extra fenced-code-blocks pygments

--- a/test/tm-cases/quoted_fenced_code_blocks_whitespace_around_indented_lines.text
+++ b/test/tm-cases/quoted_fenced_code_blocks_whitespace_around_indented_lines.text
@@ -1,0 +1,12 @@
+### Example:
+
+> ```python
+> if True:
+>     print()
+> 
+>     print()
+> 
+>     print()
+> 
+>     print()
+> ```


### PR DESCRIPTION
Fix code surrounded by blank lines inside blockquote fenced code blocks being detected as code blocks.
This is a wordy and niche problem but in essence, this:
````
> ```python
> if True:
>     print()
> 
>     print()
> 
>     print()
> 
>     print()
> ```
````

Would be rendered like this:
```html
<blockquote>
  <div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
    <span class="nb">print</span><span class="p">()</span>

<pre><code>&lt;span class="nb"&gt;print&lt;/span&gt;&lt;span class="p"&gt;()&lt;/span&gt;

&lt;span class="nb"&gt;print&lt;/span&gt;&lt;span class="p"&gt;()&lt;/span&gt;
</code></pre>
  
      <span class="nb">print</span><span class="p">()</span>
  </code></pre></div>
</blockquote>
```

This is because of the regular expression in `Markdown._do_code_blocks`. The expression would detect the middle two `print()` calls as a code block, due to the indentation and whatnot, and the regex look-ahead in that expression would not detect that this code was already inside a code block.
```regex
(?![^<]*\</code\>)
```
The existing look-ahead, as shown above, will look for `</code>` tags, however, it will only check the very next HTML tag it finds. Due to code highlighting being used in the fenced code block, this HTML tag will very likely be a `<span>` tag, resulting in a false negative.
```regex
(?!([^<]|<(/?)span)*\</code\>)
```
This updated look-ahead should do the same thing, except it will skip any `<span>` opening and closing tags.


I have run the test suite on my machine and this seems to work as intended, however, I do not have a lot of experience with regular expressions, so if there is a better way to do this or if there are any issues with the proposed fix I would love to hear your feedback.