### PR TITLE
Fix inline code pipe symbol within tables (issue #399)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1059,7 +1059,7 @@ class Markdown(object):
     def _table_sub(self, match):
         trim_space_re = '^[ \t\n]+|[ \t\n]+$'
         trim_bar_re = r'^\||\|$'
-        split_bar_re = r'^\||(?<!\\)\|'
+        split_bar_re = r'^\||(?<![\`\\])\|'
         escape_bar_re = r'\\\|'
 
         head, underline, body = match.groups()

--- a/test/tm-cases/inline_code_pipe_within_table.html
+++ b/test/tm-cases/inline_code_pipe_within_table.html
@@ -1,0 +1,21 @@
+<table>
+<thead>
+<tr>
+  <th>Sign</th>
+  <th>Operator name</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><code>&amp;</code></td>
+  <td>Bitwise and</td>
+  <td>Bitwise and between two integer values</td>
+</tr>
+<tr>
+  <td><code>|</code></td>
+  <td>Bitwise or</td>
+  <td>Bitwise or between two integer values</td>
+</tr>
+</tbody>
+</table>

--- a/test/tm-cases/inline_code_pipe_within_table.opts
+++ b/test/tm-cases/inline_code_pipe_within_table.opts
@@ -1,0 +1,1 @@
+{"extras": ["tables"]}

--- a/test/tm-cases/inline_code_pipe_within_table.tags
+++ b/test/tm-cases/inline_code_pipe_within_table.tags
@@ -1,0 +1,1 @@
+extra tables

--- a/test/tm-cases/inline_code_pipe_within_table.text
+++ b/test/tm-cases/inline_code_pipe_within_table.text
@@ -1,0 +1,4 @@
+| Sign | Operator name | Description |
+|---|---|---|
+| `&` | Bitwise and | Bitwise and between two integer values |
+| `|` | Bitwise or | Bitwise or between two integer values |


### PR DESCRIPTION
The issue (#399) was that this table:
```
| Sign | Operator name | Description |
|---|---|---|
| `&` | Bitwise and | Bitwise and between two integer values |
| `|` | Bitwise or | Bitwise or between two integer values |
```
Would be rendered incorrectly due to the "\`|`" being detected as part of the table, and not as the contents of the table.

The original regex (```^\||(?<!\\)\|```) for splitting a table by the cells within it would exclude pipe symbols preceded by a back-slash.
The updated regex (```^\||(?<![\`\\])\|```) will also exclude pipe symbols preceded by a backtick