### PR TITLE
Fix code block parsing error (issue #327)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1844,10 +1844,10 @@ class Markdown(object):
     def _code_block_sub(self, match, is_fenced_code_block=False):
         lexer_name = None
         if is_fenced_code_block:
-            lexer_name = match.group(1)
+            lexer_name = match.group(2)
             if lexer_name:
                 formatter_opts = self.extras['fenced-code-blocks'] or {}
-            codeblock = match.group(2)
+            codeblock = match.group(3)
             codeblock = codeblock[:-1]  # drop one trailing newline
         else:
             codeblock = match.group(1)
@@ -1929,9 +1929,9 @@ class Markdown(object):
 
     _fenced_code_block_re = re.compile(r'''
         (?:\n+|\A\n?)
-        ^```\s{0,99}?([\w+-]+)?\s{0,99}?\n  # opening fence, $1 = optional lang
-        (.*?)                             # $2 = code block content
-        ^```[ \t]*\n                      # closing fence
+        (^`{3,})\s{0,99}?([\w+-]+)?\s{0,99}?\n  # $1 = opening fence (captured for back-referencing), $2 = optional lang
+        (.*?)                             # $3 = code block content
+        \1[ \t]*\n                      # closing fence
         ''', re.M | re.X | re.S)
 
     def _fenced_code_block_sub(self, match):

--- a/test/tm-cases/fenced_code_blocks_issue327.html
+++ b/test/tm-cases/fenced_code_blocks_issue327.html
@@ -1,0 +1,22 @@
+<p>Inner code blocks should not render as code blocks</p>
+
+<pre><code>```cpp
+int x = 10;
+```
+</code></pre>
+
+<p>Without language specifier</p>
+
+<pre><code>```
+int x = 10;
+```
+</code></pre>
+
+<p>Double nesting</p>
+
+<pre><code>````
+```cpp
+int x = 10;
+```
+````
+</code></pre>

--- a/test/tm-cases/fenced_code_blocks_issue327.opts
+++ b/test/tm-cases/fenced_code_blocks_issue327.opts
@@ -1,0 +1,1 @@
+{"extras": ["fenced-code-blocks"]}

--- a/test/tm-cases/fenced_code_blocks_issue327.tags
+++ b/test/tm-cases/fenced_code_blocks_issue327.tags
@@ -1,0 +1,1 @@
+extra fenced-code-blocks

--- a/test/tm-cases/fenced_code_blocks_issue327.text
+++ b/test/tm-cases/fenced_code_blocks_issue327.text
@@ -1,0 +1,23 @@
+Inner code blocks should not render as code blocks
+
+````
+```cpp
+int x = 10;
+```
+````
+
+Without language specifier
+````
+```
+int x = 10;
+```
+````
+
+Double nesting
+`````
+````
+```cpp
+int x = 10;
+```
+````
+`````


### PR DESCRIPTION
As stated in issue #327, Markdown allows for inserting fenced code blocks within other fenced code blocks, provided that the outer code block has one more back-tick than the inner one.
EG :
``````
````
```cpp
int x = 10;
```
````
```````

The previous regex for fenced code blocks would look for lines starting with three back-ticks only. The new regex checks for lines starting with three or more back-ticks and then uses a back reference to find an identical closing set of back-ticks.

The disadvantage of this is that the opening back-ticks have to be captured for the back reference to work, which makes it the first group of the `re.Match` that gets passed to `_code_block_sub`