### PR TITLE
Fix unexpected md5-* in resulting HTML when several code blocks follow one by one (issue #355)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1928,7 +1928,7 @@ class Markdown(object):
         return code_block_re.sub(self._code_block_sub, text)
 
     _fenced_code_block_re = re.compile(r'''
-        (?:\n+|\A\n?)
+        (?:\n+|\A\n?|(?<=\n))
         (^`{3,})\s{0,99}?([\w+-]+)?\s{0,99}?\n  # $1 = opening fence (captured for back-referencing), $2 = optional lang
         (.*?)                             # $3 = code block content
         \1[ \t]*\n                      # closing fence

--- a/test/tm-cases/fenced_code_blocks_issue355.html
+++ b/test/tm-cases/fenced_code_blocks_issue355.html
@@ -1,0 +1,10 @@
+<div class="codehilite"><pre><span></span><code><span class="n">some</span> <span class="n">code</span> <span class="n">block</span>
+</code></pre></div>
+
+<pre><code>yet another code block
+</code></pre>
+
+<p>new line:</p>
+
+<pre><code>code everywhere
+</code></pre>

--- a/test/tm-cases/fenced_code_blocks_issue355.opts
+++ b/test/tm-cases/fenced_code_blocks_issue355.opts
@@ -1,0 +1,1 @@
+{"extras": ["fenced-code-blocks"]}

--- a/test/tm-cases/fenced_code_blocks_issue355.tags
+++ b/test/tm-cases/fenced_code_blocks_issue355.tags
@@ -1,0 +1,1 @@
+extra fenced-code-blocks pygments

--- a/test/tm-cases/fenced_code_blocks_issue355.text
+++ b/test/tm-cases/fenced_code_blocks_issue355.text
@@ -1,0 +1,10 @@
+```python
+some code block
+```
+```
+yet another code block
+```
+new line:
+```
+code everywhere
+```


### PR DESCRIPTION
The `_fenced_code_block_re` would look for fenced code blocks surrounded by `\n` characters.
However, if two code blocks were separated by only a single `\n` then that `\n` would be matched as part of the first code block. 
EG:
````
            ---
```          |
some code    |  The first code block, successfully matched
```          |
            ---
```         ---
some code    | What the regex tries to match against the second time
```         ---
````
The second code block is now without a preceding `\n`, due to the fact that overlaps are not allowed, and since code blocks are required to have a preceding and following `\n`, the second block does not get matched.

The proposed fix adds a look-behind assertion to check if the code block is preceded by a `\n` character, ignoring the overlap.
EG:
````
            ---
```          |
some code    |  The first code block, successfully matched
```          |
            ===
```          |
some code    | The now recognized second code block, sharing a \n with the first
```         ---
````