### PR TITLE
Fix backslashes removed by adjacent code blocks (issues #369 and #412)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -256,6 +256,7 @@ class Markdown(object):
         self.cli = cli
 
         self._escape_table = g_escape_table.copy()
+        self._code_table = {}
         if "smarty-pants" in self.extras:
             self._escape_table['"'] = _hash_text('"')
             self._escape_table["'"] = _hash_text("'")
@@ -2005,7 +2006,7 @@ class Markdown(object):
         for before, after in replacements:
             text = text.replace(before, after)
         hashed = _hash_text(text)
-        self._escape_table[text] = hashed
+        self._code_table[text] = hashed
         return hashed
 
     _strike_re = re.compile(r"~~(?=\S)(.+?)(?<=\S)~~", re.S)
@@ -2335,7 +2336,7 @@ class Markdown(object):
 
     def _unescape_special_chars(self, text):
         # Swap back in all the special characters we've hidden.
-        for ch, hash in list(self._escape_table.items()):
+        for ch, hash in list(self._escape_table.items()) + list(self._code_table.items()):
             text = text.replace(hash, ch)
         return text
 

--- a/test/tm-cases/backslash_removed_by_adjacent_backtick.html
+++ b/test/tm-cases/backslash_removed_by_adjacent_backtick.html
@@ -1,0 +1,7 @@
+<p>hello \world</p>
+
+<p>hello \world my favourite letter is <code>w</code></p>
+
+<p>hello \world my favourite code is <code>import pickle</code></p>
+
+<p>hello \world my favourite letter is <code>x</code></p>

--- a/test/tm-cases/backslash_removed_by_adjacent_backtick.text
+++ b/test/tm-cases/backslash_removed_by_adjacent_backtick.text
@@ -1,0 +1,7 @@
+hello \world
+
+hello \world my favourite letter is `w`
+
+hello \world my favourite code is `import pickle`
+
+hello \world my favourite letter is `x`


### PR DESCRIPTION
The issue, as stated in #369 is:
> ... backslashes are removed by adding backticks ... but only if the phrase inside the backticks is a prefix of the word following the backslash

EG:
```python
>>> markdown2.markdown('hello \world! My favourite letter is `w`')
'<p>hello world! My favourite letter is <code>w</code>.</p>\n'
```

@mhils found in #412 that the section within the backticks (`w` in this case) ends up in the `_escape_table`. Later, when `_encode_backslash_escapes` is called, it replaces anything in `_escape_table` prefixed by `\\`, meaning that the `\w` in `hello \world` gets escaped.

How the characters end up in the `_escape_table` is via the `_encode_code` code function.
The proposed fix changes `_encode_code` so that code is instead placed inside a `_code_table` dictionary, which is unused by `_encode_backslash_escapes`. The items in `_code_tables` can then be placed back into the text in `_unescape_special_chars`