### PR TITLE
Fix excessive `<br>` tags in lists using `break-on-newline` extra (issue #394)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1220,7 +1220,7 @@ class Markdown(object):
 
         # Do hard breaks:
         if "break-on-newline" in self.extras:
-            text = re.sub(r" *\n", "<br%s\n" % self.empty_element_suffix, text)
+            text = re.sub(r" *\n(?!\<(?:ul|li)\>)", "<br%s\n" % self.empty_element_suffix, text)
         else:
             text = re.sub(r" {2,}\n", " <br%s\n" % self.empty_element_suffix, text)
 

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1220,7 +1220,7 @@ class Markdown(object):
 
         # Do hard breaks:
         if "break-on-newline" in self.extras:
-            text = re.sub(r" *\n(?!\<(?:ul|li)\>)", "<br%s\n" % self.empty_element_suffix, text)
+            text = re.sub(r" *\n(?!\<(?:\/?(ul|ol|li))\>)", "<br%s\n" % self.empty_element_suffix, text)
         else:
             text = re.sub(r" {2,}\n", " <br%s\n" % self.empty_element_suffix, text)
 

--- a/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.html
+++ b/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.html
@@ -1,0 +1,17 @@
+<h2>Conteúdo</h2>
+
+<ul>
+<li>O que é estrutura Co-locada (on premises), o que é estrutura híbrida e o que é estrutura em-nuvem?
+<ul>
+<li>Em Nuvem (cloud based)</li>
+<li>Uma estrutura em-nuvem tem todos os seus principais recursos providos por um provedor de serviços em nuvem.
+<ul>
+<li>Uma definição formal de serviço em nuvem pode ser:</li>
+<li>Entrega via internet de um serviço de Tecnologia da Informação, sob demanda, em um modelo de pague-pelo-que-consome.
+<ul>
+<li>Brown Field é quando você migra um serviço existente</li>
+<li>Green field é quando você começa do zero na nuvem, alguns também chamam isto de Cloud </li><br /><br /><br />
+</ul></li><br /><br />
+</ul></li><br />
+</ul></li>
+</ul>

--- a/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.html
+++ b/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.html
@@ -10,8 +10,45 @@
 <li>Entrega via internet de um serviço de Tecnologia da Informação, sob demanda, em um modelo de pague-pelo-que-consome.
 <ul>
 <li>Brown Field é quando você migra um serviço existente</li>
-<li>Green field é quando você começa do zero na nuvem, alguns também chamam isto de Cloud </li><br /><br /><br />
-</ul></li><br /><br />
-</ul></li><br />
+<li>Green field é quando você começa do zero na nuvem, alguns também chamam isto de Cloud </li>
+</ul></li>
+</ul></li>
 </ul></li>
 </ul>
+
+<h2>Ordered List</h2>
+
+<ol>
+<li>A
+<ol>
+<li>B
+<ol>
+<li>C
+<ol>
+<li>D</li>
+<li>E</li>
+</ol></li>
+</ol></li>
+</ol></li>
+</ol>
+
+<h2>Mixed List</h2>
+
+<ol>
+<li>A
+<ul>
+<li>B
+<ol>
+<li>C
+<ul>
+<li>D</li>
+<li>E</li>
+</ul></li>
+<li>F
+<ol>
+<li>G</li>
+<li>H</li>
+</ol></li>
+</ol></li>
+</ul></li>
+</ol>

--- a/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.opts
+++ b/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.opts
@@ -1,0 +1,1 @@
+{"extras": ["break-on-newline"]}

--- a/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.text
+++ b/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.text
@@ -6,3 +6,20 @@
         - Entrega via internet de um serviço de Tecnologia da Informação, sob demanda, em um modelo de pague-pelo-que-consome.
           - Brown Field é quando você migra um serviço existente
           - Green field é quando você começa do zero na nuvem, alguns também chamam isto de Cloud 
+
+## Ordered List
+1. A
+    1. B
+        1. C
+            1. D
+            2. E
+
+## Mixed List
+1. A
+    - B
+        1. C
+            - D
+            - E
+        2. F
+            1. G
+            2. H

--- a/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.text
+++ b/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.text
@@ -1,0 +1,8 @@
+## Conteúdo
+- O que é estrutura Co-locada (on premises), o que é estrutura híbrida e o que é estrutura em-nuvem?
+  - Em Nuvem (cloud based)
+    - Uma estrutura em-nuvem tem todos os seus principais recursos providos por um provedor de serviços em nuvem.
+      - Uma definição formal de serviço em nuvem pode ser:
+        - Entrega via internet de um serviço de Tecnologia da Informação, sob demanda, em um modelo de pague-pelo-que-consome.
+          - Brown Field é quando você migra um serviço existente
+          - Green field é quando você começa do zero na nuvem, alguns também chamam isto de Cloud 


### PR DESCRIPTION
The `break-on-newline` extra uses a regexp to replace 0 or more spaces followed by a new line, with a `<br />` tag.
This is a problem for `<ul>`, `<ol>` and mixed lists, where list items are defined on new lines.
Something like
```
- Item 1
    - Item 2
```
Could end up as:
```html
<ul>
<li>Item 1<br />
<ul><br />
<li>Item 2</li><br />
</ul></li>
</ul>
```
![image](https://user-images.githubusercontent.com/57498990/159745296-cb31bac6-ee5b-40c4-bce0-510e2788317d.png)

The proposed fix replaces 0 or more spaces followed by a new line, but only if they are not followed by a `ul`, `ol` or `li` opening/closing tag.