### PR TITLE
Standardize key and value definitions for metadata extra (issue #423)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -444,14 +444,20 @@ class Markdown(object):
     #   another-var: blah blah
     #
     #   # header
-    _meta_data_pattern = re.compile(r'^(?:---[\ \t]*\n)?((?:[\S\w]+\s*:(?:\n+[ \t]+.*)+)|(?:.*:\s+>\n\s+[\S\s]+?)(?=\n\w+\s*:\s*\w+\n|\Z)|(?:\s*[\S\w]+\s*:(?! >)[ \t]*.*\n?))(?:---[\ \t]*\n)?', re.MULTILINE)
-    _key_val_pat = re.compile(r"[\S\w]+\s*:(?! >)[ \t]*.*\n?", re.MULTILINE)
-    # this allows key: >
-    #                   value
-    #                   conutiues over multiple lines
-    _key_val_block_pat = re.compile(
-        r"(.*:\s+>\n\s+[\S\s]+?)(?=\n\w+\s*:\s*\w+\n|\Z)", re.MULTILINE
+    _meta_data_pattern = re.compile(r'''
+        ^(?:---[\ \t]*\n)?(  # optional opening fence
+            (?:
+                [\S \t]+\s*:(?:\n+[ \t]+.*)+  # indented lists
+            )|(?:
+                (?:[\S \t]+\s*:\s+>(?:\n\s+.*)+?)  # multiline long descriptions
+                (?=\n[\S \t]+\s*:\s*.*\n|\s*\Z)  # match up until the start of the next key:value definition or the end of the input text
+            )|(?:
+                \s*[\S \t]+\s*:(?! >)[ \t]*.*\n?  # simple key:value pair, leading spaces allowed
+            )
+        )(?:---[\ \t]*\n)?  # optional closing fence
+        ''', re.MULTILINE | re.VERBOSE
     )
+
     _key_val_list_pat = re.compile(
         r"^-(?:[ \t]*([^\n]*)(?:[ \t]*[:-][ \t]*(\S+))?)(?:\n((?:[ \t]+[^\n]+\n?)+))?",
         re.MULTILINE,

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -447,12 +447,12 @@ class Markdown(object):
     _meta_data_pattern = re.compile(r'''
         ^(?:---[\ \t]*\n)?(  # optional opening fence
             (?:
-                [\S \t]+\s*:(?:\n+[ \t]+.*)+  # indented lists
+                [\S \t]*\w[\S \t]*\s*:(?:\n+[ \t]+.*)+  # indented lists
             )|(?:
-                (?:[\S \t]+\s*:\s+>(?:\n\s+.*)+?)  # multiline long descriptions
-                (?=\n[\S \t]+\s*:\s*.*\n|\s*\Z)  # match up until the start of the next key:value definition or the end of the input text
+                (?:[\S \t]*\w[\S \t]*\s*:\s+>(?:\n\s+.*)+?)  # multiline long descriptions
+                (?=\n[\S \t]*\w[\S \t]*\s*:\s*.*\n|\s*\Z)  # match up until the start of the next key:value definition or the end of the input text
             )|(?:
-                \s*[\S \t]+\s*:(?! >).*\n?  # simple key:value pair, leading spaces allowed
+                [\S \t]*\w[\S \t]*\s*:(?! >).*\n?  # simple key:value pair, leading spaces allowed
             )
         )(?:---[\ \t]*\n)?  # optional closing fence
         ''', re.MULTILINE | re.VERBOSE

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -452,7 +452,7 @@ class Markdown(object):
                 (?:[\S \t]+\s*:\s+>(?:\n\s+.*)+?)  # multiline long descriptions
                 (?=\n[\S \t]+\s*:\s*.*\n|\s*\Z)  # match up until the start of the next key:value definition or the end of the input text
             )|(?:
-                \s*[\S \t]+\s*:(?! >)[ \t]*.*\n?  # simple key:value pair, leading spaces allowed
+                \s*[\S \t]+\s*:(?! >).*\n?  # simple key:value pair, leading spaces allowed
             )
         )(?:---[\ \t]*\n)?  # optional closing fence
         ''', re.MULTILINE | re.VERBOSE

--- a/test/tm-cases/metadata3.html
+++ b/test/tm-cases/metadata3.html
@@ -1,0 +1,1 @@
+<p>This tests various metadata key:value configurations to make sure they will work well consecutively</p>

--- a/test/tm-cases/metadata3.metadata
+++ b/test/tm-cases/metadata3.metadata
@@ -1,0 +1,26 @@
+{
+    "basic": "value",
+    "basic2": "test consecutive basic keys",
+    "empty": "",
+    "empty2": "",
+    "long-desc": "long multiline\n  description\nwith varying levels of\n    indentation",
+    "long-desc2": "test consecutive long descriptions",
+    "nested": [
+        "list item",
+        "following a long description"
+    ],
+    "nested2": [
+        "consecutive nested"
+    ],
+    "nested3": [
+        {
+            "subkey": "with subkeys"
+        }
+    ],
+    "long-desc3": "long description following a nested",
+    "empty-following-long-desc": "",
+    "key with spaces": "will also be recognized",
+    "-key_start_with_hyphen": "allowed",
+    "tab indented key": "allowed",
+    "finish-with": "a nice long description\nover a couple lines"
+}

--- a/test/tm-cases/metadata3.opts
+++ b/test/tm-cases/metadata3.opts
@@ -1,0 +1,1 @@
+{"extras": ["metadata"]}

--- a/test/tm-cases/metadata3.text
+++ b/test/tm-cases/metadata3.text
@@ -1,4 +1,5 @@
 ---
+ : empty key should be ignored
 basic: value
 basic2: test consecutive basic keys
 empty:

--- a/test/tm-cases/metadata3.text
+++ b/test/tm-cases/metadata3.text
@@ -1,0 +1,32 @@
+---
+basic: value
+basic2: test consecutive basic keys
+empty:
+empty2  :     
+long-desc: >
+  long multiline
+    description
+  with varying levels of
+      indentation
+long-desc2: >
+  test consecutive long descriptions
+nested:
+  - list item
+  - following a long description
+nested2:
+  - consecutive nested
+nested3:
+  -
+    subkey: with subkeys
+long-desc3: >
+  long description following a nested
+empty-following-long-desc:
+key with spaces: will also be recognized
+-key_start_with_hyphen: allowed
+  tab indented key: allowed
+finish-with : >
+  a nice long description
+  over a couple lines
+---
+
+This tests various metadata key:value configurations to make sure they will work well consecutively


### PR DESCRIPTION
As discussed in #423 , the `_meta_data_pattern` regexp had some inconsistent definitions for what metadata `key:value` pairs were allowed to contain.

This PR defines keys as `[\S \t]*\w[\S \t]*\s*:` and values as `.*`
I found the keys much harder to define but the proposed definition:
  - Requires at least one word character
  - Can contain spaces, tabs, hyphens and other symbols
  - Can have whitespace before the colon
  - Feels somewhat clunky

Metadata values were much easier as I just used the most inclusive character class available.

This PR also removes the `_key_val_pat` and `_key_val_block_pat` class variables because I couldn't find anywhere in the codebase that they were being used.