### PR TITLE
Don't test library against unsupported Python versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ was written to closely match the behaviour of the original Perl-implemented
 Markdown.pl. Markdown2 also comes with a number of extensions (called
 "extras") for things like syntax coloring, tables, header-ids. See the
 "Extra Syntax" section below. "markdown2" supports all Python versions
-2.6+ or 3.3+ (and pypy and jython, though I don't frequently test those).
+3.5+ (and pypy and jython, though I don't frequently test those).
 
 There is another [Python
 markdown.py](https://python-markdown.github.io/). However, at
@@ -48,14 +48,14 @@ As a module:
 ```python
 >>> import markdown2
 >>> markdown2.markdown("*boo!*")  # or use `html = markdown_path(PATH)`
-u'<p><em>boo!</em></p>\n'
+'<p><em>boo!</em></p>\n'
 
 >>> from markdown2 import Markdown
 >>> markdowner = Markdown()
 >>> markdowner.convert("*boo!*")
-u'<p><em>boo!</em></p>\n'
+'<p><em>boo!</em></p>\n'
 >>> markdowner.convert("**boom!**")
-u'<p><strong>boom!</strong></p>\n'
+'<p><strong>boom!</strong></p>\n'
 ```
 As a script (CLI):
 ```shell
@@ -88,7 +88,7 @@ as a script:
 ```shell
 >>> import markdown2
 >>> markdown2.markdown("*boo!*", extras=["footnotes"])
-u'<p><em>boo!</em></p>\n'
+'<p><em>boo!</em></p>\n'
 ```
 There are a number of currently implemented extras for tables, footnotes,
 syntax coloring of `<pre>`-blocks, auto-linking patterns, table of contents,

--- a/test/testall.py
+++ b/test/testall.py
@@ -26,7 +26,8 @@ def _python_ver_from_python(python):
 
 def _gen_python_names():
     yield "python"
-    for ver in [(2,6), (2,7), (3,3), (3,4), (3,5), (3,6), (3,7)]:
+    # generate version numbers from python 3.5 to 3.20
+    for ver in [(3, i) for i in range(5, 20)]:
         yield "python%d.%d" % ver
         if sys.platform == "win32":
             yield "python%d%d" % ver
@@ -43,8 +44,8 @@ def _gen_pythons():
 
 def testall():
     for ver, python in _gen_pythons():
-        if ver < (2,6) or ver in ((3,0), (3,1), (3,2)):
-            # Don't support Python < 2.6, 3.0/3.1/3.2.
+        if ver < (3, 5):
+            # Don't support Python < 3.5
             continue
         ver_str = "%s.%s" % ver
         print("-- test with Python %s (%s)" % (ver_str, python))


### PR DESCRIPTION
This PR updates the test suite to no longer test against any Python version lower than 3.5.

Previously the test suite would detect installed python versions from a hard-coded list of supported versions, ranging from 2.6-2.7 and 3.3-3.7, which becomes out of date every year when Python has a new version release.

The proposed change generates Python version numbers from 3.5 up to (but not including) 3.20 which means that the upper end of the range shouldn't need to be changed for 8 or so years and the lower end of the range can easily be bumped up as older Python versions loose support.