### PR TITLE
Fix fenced code blocks breaking lists (issue #426)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1879,10 +1879,17 @@ class Markdown(object):
                 return codeblock
             lexer = self._get_pygments_lexer(lexer_name)
             if lexer:
+                # calculate code block's leading indent to not break lists
+                leading_indent = re.match(r'[ \t]*(?=`{3,})', match.group(1))
+                if leading_indent is not None:
+                    leading_indent = leading_indent.group(0)
+                else:
+                    leading_indent = ''
+
                 codeblock = unhash_code( codeblock )
                 colored = self._color_with_pygments(codeblock, lexer,
                                                     **formatter_opts)
-                return "\n\n%s\n\n" % colored
+                return "\n\n%s%s\n\n" % (leading_indent, colored)
 
         codeblock = self._encode_code(codeblock)
         pre_class_str = self._html_class_str_from_tag("pre")
@@ -1930,7 +1937,7 @@ class Markdown(object):
 
     _fenced_code_block_re = re.compile(r'''
         (?:\n+|\A\n?|(?<=\n))
-        (^`{3,})\s{0,99}?([\w+-]+)?\s{0,99}?\n  # $1 = opening fence (captured for back-referencing), $2 = optional lang
+        (^[ \t]*`{3,})\s{0,99}?([\w+-]+)?\s{0,99}?\n  # $1 = opening fence (captured for back-referencing), $2 = optional lang
         (.*?)                             # $3 = code block content
         \1[ \t]*\n                      # closing fence
         ''', re.M | re.X | re.S)

--- a/test/tm-cases/fenced_code_blocks_issue426.html
+++ b/test/tm-cases/fenced_code_blocks_issue426.html
@@ -1,0 +1,31 @@
+<h1>Django Templates</h1>
+
+<h2>NOTES</h2>
+
+<ul>
+<li>The name should map to the URL.</li>
+<li>No distro or app name prefix, they are namespaced by their dirs already</li>
+<li>Since templates are made in python, the are <code>named_with_underscores.html</code> (not web style dashes).</li>
+</ul>
+
+<h2>URL PARAMETERS IN THE TEMPLATE</h2>
+
+<ul>
+<li>All views (except <code>generic.View</code>) from <code>django.forms.generic</code> inherit from <code>ContextMixin</code></li>
+<li><p><code>ContextMixin</code> defines the method <code>get_context_data</code>:</p>
+
+<div class="codehilite"><pre><span></span><code>    <span class="k">def</span> <span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+    <span class="n">kwargs</span><span class="o">.</span><span class="n">setdefault</span><span class="p">(</span><span class="s1">&#39;view&#39;</span><span class="p">,</span> <span class="bp">self</span><span class="p">)</span>
+    <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">extra_context</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">kwargs</span><span class="o">.</span><span class="n">update</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">extra_context</span><span class="p">)</span>
+    <span class="k">return</span> <span class="n">kwargs</span>
+</code></pre></div>
+
+<p>So when overriding one must be careful to extends <code>super</code>'s <code>kwargs</code>:</p>
+
+<div class="codehilite"><pre><span></span><code>    <span class="k">def</span> <span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+    <span class="n">kwargs</span> <span class="o">=</span> <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="n">get_context_data</span><span class="p">(</span><span class="o">**</span><span class="n">kwargs</span><span class="p">)</span>
+    <span class="n">kwargs</span><span class="p">[</span><span class="s1">&#39;page_title&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s2">&quot;Documentation&quot;</span>
+    <span class="k">return</span> <span class="n">kwargs</span>
+</code></pre></div></li>
+</ul>

--- a/test/tm-cases/fenced_code_blocks_issue426.opts
+++ b/test/tm-cases/fenced_code_blocks_issue426.opts
@@ -1,0 +1,1 @@
+{"extras": ["fenced-code-blocks", "pygments"]}

--- a/test/tm-cases/fenced_code_blocks_issue426.tags
+++ b/test/tm-cases/fenced_code_blocks_issue426.tags
@@ -1,0 +1,1 @@
+extra fenced-code-blocks pygments

--- a/test/tm-cases/fenced_code_blocks_issue426.text
+++ b/test/tm-cases/fenced_code_blocks_issue426.text
@@ -1,0 +1,26 @@
+# Django Templates
+
+## NOTES
+
+- The name should map to the URL.
+- No distro or app name prefix, they are namespaced by their dirs already
+- Since templates are made in python, the are `named_with_underscores.html` (not web style dashes).
+
+## URL PARAMETERS IN THE TEMPLATE
+
+- All views (except `generic.View`) from `django.forms.generic` inherit from `ContextMixin`
+- `ContextMixin` defines the method `get_context_data`:
+    ```python
+    def get_context_data(self, **kwargs):
+        kwargs.setdefault('view', self)
+        if self.extra_context is not None:
+            kwargs.update(self.extra_context)
+        return kwargs
+    ```
+    So when overriding one must be careful to extends `super`'s `kwargs`:
+    ```py
+    def get_context_data(self, **kwargs):
+        kwargs = super().get_context_data(**kwargs)
+        kwargs['page_title'] = "Documentation"
+        return kwargs
+    ```


### PR DESCRIPTION
The problem was that fenced code blocks would not be detected if placed inside a list (ul/ol) due to
the leading indentation before the opening code fence.
This PR tweaks the `_fenced_code_block_re` to ignore leading space/tab indents before an opening fence.

`_code_block_sub` has also been altered to maintain the leading indentation when inserting code hashes as
to not break the list (ul/ol) that the fenced code block is in, so instead of this:
```html
<h2>URL PARAMETERS IN THE TEMPLATE</h2>

<ul>
<li>All views (except <code>md5-e492587862bc07a3e8a1766f3b6cdf9f</code>) from <code>md5-13862f106a0084500eb9518428d220d5</code> inherit from <code>md5-cb5cca48ea3a39d2e5f4f32ed57fe64e</code></li>
<li><code>md5-cb5cca48ea3a39d2e5f4f32ed57fe64e</code> defines the method <code>md5-e7f43ed59796b5da4b301f5cdc8ee0d1</code>:</li>
</ul>

md5-9b355e37bf17872e1d8fa0ef265c0b94


    So when overriding one must be careful to extends `super`'s `kwargs`:


md5-e6db16759f697cd8b6f6220aaa2a9f78
```
The output HTML looks more like this:
```html
<h2>URL PARAMETERS IN THE TEMPLATE</h2>

<ul>
<li>All views (except <code>md5-e492587862bc07a3e8a1766f3b6cdf9f</code>) from <code>md5-13862f106a0084500eb9518428d220d5</code> inherit from <code>md5-cb5cca48ea3a39d2e5f4f32ed57fe64e</code></li>
<li><code>md5-cb5cca48ea3a39d2e5f4f32ed57fe64e</code> defines the method <code>md5-e7f43ed59796b5da4b301f5cdc8ee0d1</code>:

    md5-9b355e37bf17872e1d8fa0ef265c0b94


    <p>So when overriding one must be careful to extends `super`'s `kwargs`:</p>


    md5-e6db16759f697cd8b6f6220aaa2a9f78
</li></ul>
```