### PR TITLE
fix catastrophic backtracking in pyshell code blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - [pull #422] Fix excessive <br> tags in lists using break-on-newline extra (issue #394)
 - [pull #424] Standardize key and value definitions for metadata extra (issue #423)
 - [pull #427] Fix fenced code blocks breaking lists (issue #426)
+- [pull #428] Fix catastrophic backtracking (Regex DoS) in pyshell blocks.
 
 
 ## python-markdown2 2.4.2

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1056,8 +1056,8 @@ class Markdown(object):
 
         less_than_tab = self.tab_width - 1
         _pyshell_block_re = re.compile(r"""
-            ^([ ]{0,%d})>>>[ ].*\n   # first line
-            ^(\1.*\S+.*\n)*         # any number of subsequent lines
+            ^([ ]{0,%d})>>>[ ].*\n  # first line
+            ^(\1[^\S\n]*\S.*\n)*    # any number of subsequent lines with at least one character
             ^\n                     # ends with a blank line
             """ % less_than_tab, re.M | re.X)
 


### PR DESCRIPTION
Found in https://github.com/mitmproxy/pdoc/issues/376: The following docstring takes ages to process due to catastrophic backtracking:

```
Foo the foo.


###### Examples
> >>> class Foo(object):
> ...     pass
> >>> foo = Foo()
> >>> paths = foo.foo(dir_="src")
> >>> [str(p) for p in paths][:2]
> ['foo', 'bar']

```

This PR fixes the corresponding regular expression. :)