### PR TITLE
Fix incorrect indentation of fenced code blocks within lists

### DIFF
--- a/test/tm-cases/fenced_code_blocks_issue426.html
+++ b/test/tm-cases/fenced_code_blocks_issue426.html
@@ -14,7 +14,7 @@
 <li>All views (except <code>generic.View</code>) from <code>django.forms.generic</code> inherit from <code>ContextMixin</code></li>
 <li><p><code>ContextMixin</code> defines the method <code>get_context_data</code>:</p>
 
-<div class="codehilite"><pre><span></span><code>    <span class="k">def</span> <span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+<div class="codehilite"><pre><span></span><code><span class="k">def</span> <span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
     <span class="n">kwargs</span><span class="o">.</span><span class="n">setdefault</span><span class="p">(</span><span class="s1">&#39;view&#39;</span><span class="p">,</span> <span class="bp">self</span><span class="p">)</span>
     <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">extra_context</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
         <span class="n">kwargs</span><span class="o">.</span><span class="n">update</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">extra_context</span><span class="p">)</span>
@@ -23,7 +23,7 @@
 
 <p>So when overriding one must be careful to extends <code>super</code>'s <code>kwargs</code>:</p>
 
-<div class="codehilite"><pre><span></span><code>    <span class="k">def</span> <span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+<div class="codehilite"><pre><span></span><code><span class="k">def</span> <span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
     <span class="n">kwargs</span> <span class="o">=</span> <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="n">get_context_data</span><span class="p">(</span><span class="o">**</span><span class="n">kwargs</span><span class="p">)</span>
     <span class="n">kwargs</span><span class="p">[</span><span class="s1">&#39;page_title&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s2">&quot;Documentation&quot;</span>
     <span class="k">return</span> <span class="n">kwargs</span>


### PR DESCRIPTION
In my previous PR (#427) I accidentally introduced a bug that would mess up the indentation of a fenced code block within a list.
I made the mistake of not checking the output of the `fenced_code_blocks_issue426.html` test case in a browser, where the bug is very obvious.

![image](https://user-images.githubusercontent.com/57498990/162627743-75617559-cca2-44b5-ba56-294555655c45.png)

My previous fix would only add the leading indentation to the first line of the fenced code block. (facepalm).

This new fix is alot smarter. It takes a fenced code block like this:
````
    ```python
    if True:
        print('Stuff')
    ```
````
And it figures out what the smallest common indent is for each line. In this case, each line is indented by at least 4 spaces.
We then remove this leading indentation from the fenced code block like so:
````
```python
if True:
    print('Stuff')
```
````
And run this code through the pygments processor as per usual.
```html
<div class="codehilite"><pre><span></span><code>
...
</code></pre></div>
```
Finally, we add back the leading indentation to each line to ensure that the formatted code block does not break out of whatever indented element it was part of (ul/ol/etc...)
```html
    <div class="codehilite"><pre><span></span><code>
    ...
    </code></pre></div>
```