### PR TITLE
Fix filter bypass leading to XSS (#362)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2249,7 +2249,7 @@ class Markdown(object):
         text = self._naked_gt_re.sub('&gt;', text)
         return text
 
-    _incomplete_tags_re = re.compile(r"<(/?\w+?(?!\w).+?[\s/]+?)")
+    _incomplete_tags_re = re.compile(r"<(/?\w+?(?!\w)\s*?.+?[\s/]+?)")
 
     def _encode_incomplete_tags(self, text):
         if self.safe_mode not in ("replace", "escape"):

--- a/test/tm-cases/xss_issue_362.html
+++ b/test/tm-cases/xss_issue_362.html
@@ -1,0 +1,2 @@
+<p>&lt;iframe
+onload=alert()//</p>

--- a/test/tm-cases/xss_issue_362.opts
+++ b/test/tm-cases/xss_issue_362.opts
@@ -1,0 +1,1 @@
+{"safe_mode": True}

--- a/test/tm-cases/xss_issue_362.text
+++ b/test/tm-cases/xss_issue_362.text
@@ -1,0 +1,2 @@
+<iframe
+onload=alert()//


### PR DESCRIPTION
As reported by @terjanq:

> The new regex `_incomplete_tags_re = re.compile("<(/?\w+?(?!\w).+?[\s/]+?)")` in [#351](https://github.com/trentm/python-markdown2/pull/351) introduced a more severe bypass on any HTML element by using a new line that does not match to .+.
> ```python
> In [2]: markdown2.markdown('<iframe\nonload=alert()//',safe_mode=True)
> Out[2]: '<p><iframe\nonload=alert()//</p>\n'
> ```

I was able to reproduce this issue.
The proposed change ignores whitespace between the tag name and the `.+` and from my tests this seems to do the trick.
```diff
- _incomplete_tags_re = re.compile("<(/?\w+?(?!\w).+?[\s/]+?)")
+ _incomplete_tags_re = re.compile("<(/?\w+?(?!\w)\s*.+?[\s/]+?)")
```
However, I will admit that I'm not a security guy so it's possible that this change has it's own issues.

Furthermore, I was unable to reproduce the second example given in #362, so that might already have been fixed.