### PR TITLE
RST admonitions (#401)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -354,9 +354,6 @@ class Markdown(object):
         if "fenced-code-blocks" in self.extras and not self.safe_mode:
             text = self._do_fenced_code_blocks(text)
 
-        if 'admonitions' in self.extras and not self.safe_mode:
-            text = self._do_admonitions(text)
-
         if self.safe_mode:
             text = self._hash_html_spans(text)
 
@@ -366,7 +363,7 @@ class Markdown(object):
         if "fenced-code-blocks" in self.extras and self.safe_mode:
             text = self._do_fenced_code_blocks(text)
 
-        if 'admonitions' in self.extras and self.safe_mode:
+        if 'admonitions' in self.extras:
             text = self._do_admonitions(text)
 
         # Because numbering references aren't links (yet?) then we can do everything associated with counters

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -351,11 +351,11 @@ class Markdown(object):
 
         text = self.preprocess(text)
 
-        if 'admonitions' in self.extras and not self.safe_mode:
-            text = self._do_admonitions(text)
-
         if "fenced-code-blocks" in self.extras and not self.safe_mode:
             text = self._do_fenced_code_blocks(text)
+
+        if 'admonitions' in self.extras and not self.safe_mode:
+            text = self._do_admonitions(text)
 
         if self.safe_mode:
             text = self._hash_html_spans(text)
@@ -363,11 +363,11 @@ class Markdown(object):
         # Turn block-level HTML blocks into hash entries
         text = self._hash_html_blocks(text, raw=True)
 
-        if 'admonitions' in self.extras and self.safe_mode:
-            text = self._do_admonitions(text)
-
         if "fenced-code-blocks" in self.extras and self.safe_mode:
             text = self._do_fenced_code_blocks(text)
+
+        if 'admonitions' in self.extras and self.safe_mode:
+            text = self._do_admonitions(text)
 
         # Because numbering references aren't links (yet?) then we can do everything associated with counters
         # before we get started
@@ -1903,7 +1903,7 @@ class Markdown(object):
                                                     **formatter_opts)
 
                 # add back the indent to all lines
-                return "\n\n%s\n\n" % self._uniform_indent(colored, leading_indent, True)
+                return "\n%s\n" % self._uniform_indent(colored, leading_indent, True)
 
         codeblock = self._encode_code(codeblock)
         pre_class_str = self._html_class_str_from_tag("pre")
@@ -1913,7 +1913,7 @@ class Markdown(object):
         else:
             code_class_str = self._html_class_str_from_tag("code")
 
-        return "\n\n<pre%s><code%s>%s\n</code></pre>\n\n" % (
+        return "\n<pre%s><code%s>%s\n</code></pre>\n" % (
             pre_class_str, code_class_str, codeblock)
 
     def _html_class_str_from_tag(self, tag):
@@ -2032,10 +2032,10 @@ class Markdown(object):
 
     _admonitions = r'admonition|attention|caution|danger|error|hint|important|note|tip|warning'
     _admonitions_re = re.compile(r'''
-        ^(\ *)\.\.\ (%s)::\ *         # $1 leading indent, $2 the admonition
+        ^(\ *)\.\.\ (%s)::\ *                # $1 leading indent, $2 the admonition
         (.*)?                                # $3 admonition title
-        ((?:\s*\n\1\ {3,}.*)+?)      # $4 admonition body (required)
-        (?=\s*(?:\Z|\n{3,}|\n\1?\ {0,2}\S))  # until EOF, 2 blank lines or something less indented
+        ((?:\s*\n\1\ {3,}.*)+?)              # $4 admonition body (required)
+        (?=\s*(?:\Z|\n{4,}|\n\1?\ {0,2}\S))  # until EOF, 3 blank lines or something less indented
         ''' % _admonitions,
         re.IGNORECASE | re.MULTILINE | re.VERBOSE
     )

--- a/test/tm-cases/admonitions.html
+++ b/test/tm-cases/admonitions.html
@@ -1,0 +1,51 @@
+<aside class="admonition note">
+    <strong>NOTE</strong>
+    <em>Admonitions</em>
+    <p>They contain 3 main parts, the admonition type, title and body.  </p>
+    <p>The admonition type is case insensitive, title is optional and the body
+    should be able to contain pretty much anything. For example:</p>
+    <ul>
+    <li>Lists</li>
+    <li>With multiple levels
+    <ul>
+    <li>Of indentation</li>
+    </ul></li>
+    </ul>
+    <p>And code blocks:</p>
+    <pre><code>print('indented code blocks')
+    </code></pre>
+</aside>
+
+<aside class="admonition warning">
+    <strong>warning</strong>
+    <p>The admonition's body must be indented by a tab or 3 or more spaces
+    from where the admonition was declared</p>
+</aside>
+
+<p>Otherwise the text is no longer part of the admonition.</p>
+
+<aside class="admonition important">
+    <strong>IMPORTANT</strong>
+    <p>You can also use 2 or more empty lines after an admonition <br />
+    to end it</p>
+</aside>
+
+<p>Like so.</p>
+
+<aside class="admonition">
+    <strong>admonition</strong>
+    <em>Generic admonitions</em>
+    <p>These should be given a title but this is not enforced</p>
+    <aside class="admonition note">
+        <strong>note</strong>
+        <em>Nested admonitions</em>
+        <p>Nested admonitions should also work</p>
+        <ul>
+        <li>Even inside
+        <aside class="admonition tip">
+          <strong>tip</strong>
+          <p>of a list</p>
+        </aside></li>
+        </ul>
+    </aside>
+</aside>

--- a/test/tm-cases/admonitions.html
+++ b/test/tm-cases/admonitions.html
@@ -26,11 +26,13 @@
 
 <aside class="admonition important">
     <strong>IMPORTANT</strong>
-    <p>You can also use 2 or more empty lines after an admonition <br />
+    <p>You can also use 3 or more empty lines after an admonition <br />
     to end it</p>
 </aside>
 
-<p>Like so.</p>
+<pre><code>print('In case you wanted something like')
+print('an indented code block right after')
+</code></pre>
 
 <aside class="admonition">
     <strong>admonition</strong>

--- a/test/tm-cases/admonitions.opts
+++ b/test/tm-cases/admonitions.opts
@@ -1,0 +1,1 @@
+{"extras": ["admonitions"]}

--- a/test/tm-cases/admonitions.text
+++ b/test/tm-cases/admonitions.text
@@ -18,11 +18,13 @@
   Otherwise the text is no longer part of the admonition.
 
 .. IMPORTANT::
-   You can also use 2 or more empty lines after an admonition  
+   You can also use 3 or more empty lines after an admonition  
    to end it
 
 
-Like so.
+
+    print('In case you wanted something like')
+    print('an indented code block right after')
 
 .. admonition:: Generic admonitions
 

--- a/test/tm-cases/admonitions.text
+++ b/test/tm-cases/admonitions.text
@@ -1,0 +1,36 @@
+.. NOTE:: Admonitions
+   They contain 3 main parts, the admonition type, title and body.  
+
+   The admonition type is case insensitive, title is optional and the body
+   should be able to contain pretty much anything. For example:
+
+   - Lists
+   - With multiple levels
+     - Of indentation
+
+   And code blocks:
+
+       print('indented code blocks')
+
+.. warning::
+   The admonition's body must be indented by a tab or 3 or more spaces
+   from where the admonition was declared
+  Otherwise the text is no longer part of the admonition.
+
+.. IMPORTANT::
+   You can also use 2 or more empty lines after an admonition  
+   to end it
+
+
+Like so.
+
+.. admonition:: Generic admonitions
+
+   These should be given a title but this is not enforced
+
+   .. note:: Nested admonitions
+      Nested admonitions should also work
+
+      - Even inside
+        .. tip::
+           of a list

--- a/test/tm-cases/admonitions_with_fenced_code_blocks.html
+++ b/test/tm-cases/admonitions_with_fenced_code_blocks.html
@@ -1,0 +1,20 @@
+<aside class="admonition note">
+    <strong>note</strong>
+    <p>Admonitions are able to contain fenced code blocks</p>
+    <div class="codehilite"><pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;like so&#39;</span><span class="p">)</span>
+    </code></pre></div>
+</aside>
+
+<aside class="admonition warning">
+    <strong>warning</strong>
+    <div class="codehilite"><pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;Consecutive blocks should also be fine&#39;</span><span class="p">)</span>
+    </code></pre></div>
+    <div class="codehilite"><pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;Even though fenced code blocks wrap themselves in </span><span class="se">\n\n</span><span class="s1">&#39;</span><span class="p">)</span>
+    </code></pre></div>
+    <aside class="admonition hint">
+        <strong>hint</strong>
+        <em>It should also work nested</em>
+        <div class="codehilite"><pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;ok&#39;</span><span class="p">)</span>
+        </code></pre></div>
+    </aside>
+</aside>

--- a/test/tm-cases/admonitions_with_fenced_code_blocks.html
+++ b/test/tm-cases/admonitions_with_fenced_code_blocks.html
@@ -9,7 +9,7 @@
     <strong>warning</strong>
     <div class="codehilite"><pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;Consecutive blocks should also be fine&#39;</span><span class="p">)</span>
     </code></pre></div>
-    <div class="codehilite"><pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;Even though fenced code blocks wrap themselves in </span><span class="se">\n\n</span><span class="s1">&#39;</span><span class="p">)</span>
+    <div class="codehilite"><pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;Even though fenced code blocks wrap themselves in newlines&#39;</span><span class="p">)</span>
     </code></pre></div>
     <aside class="admonition hint">
         <strong>hint</strong>
@@ -18,3 +18,8 @@
         </code></pre></div>
     </aside>
 </aside>
+
+<div class="codehilite"><pre><span></span><code><span class="c1"># admonitions WITHIN fenced code blocks should NOT be rendered</span>
+<span class="o">..</span> <span class="n">attention</span><span class="p">::</span> <span class="n">title</span>
+   <span class="n">body</span>
+</code></pre></div>

--- a/test/tm-cases/admonitions_with_fenced_code_blocks.opts
+++ b/test/tm-cases/admonitions_with_fenced_code_blocks.opts
@@ -1,0 +1,1 @@
+{"extras": ["admonitions", "fenced-code-blocks", "pygments"]}

--- a/test/tm-cases/admonitions_with_fenced_code_blocks.tags
+++ b/test/tm-cases/admonitions_with_fenced_code_blocks.tags
@@ -1,0 +1,1 @@
+extra admonitions fenced-code-blocks pygments

--- a/test/tm-cases/admonitions_with_fenced_code_blocks.text
+++ b/test/tm-cases/admonitions_with_fenced_code_blocks.text
@@ -1,0 +1,17 @@
+.. note::
+   Admonitions are able to contain fenced code blocks
+   ```python
+   print('like so')
+   ```
+
+.. warning::
+   ```python
+   print('Consecutive blocks should also be fine')
+   ```
+   ```python
+   print('Even though fenced code blocks wrap themselves in \n\n')
+   ```
+   .. hint:: It should also work nested
+      ```python
+      print('ok')
+      ```

--- a/test/tm-cases/admonitions_with_fenced_code_blocks.text
+++ b/test/tm-cases/admonitions_with_fenced_code_blocks.text
@@ -9,9 +9,15 @@
    print('Consecutive blocks should also be fine')
    ```
    ```python
-   print('Even though fenced code blocks wrap themselves in \n\n')
+   print('Even though fenced code blocks wrap themselves in newlines')
    ```
    .. hint:: It should also work nested
       ```python
       print('ok')
       ```
+
+```python
+# admonitions WITHIN fenced code blocks should NOT be rendered
+.. attention:: title
+   body
+```


### PR DESCRIPTION
This PR adds support for rendering RST admonitions as HTML `<aside>` blocks, as discussed in #401. This implementation was based on the spec laid out in the [docutils RST directives spec](https://docutils.sourceforge.io/docs/ref/rst/directives.html#admonitions).

Something like:
```rst
.. attention:: Title
   Body
```
Will be rendered as:
```html
<aside class="admonition attention">
    <strong>attention</strong>
    <em>Title</em>
    <p>Body</p>
</aside>
```
#### Leading indentation
Firstly, the leading indentation of the admonition is captured. This is to make sure the processed HTML is put back into the document at the same indentation level to avoid breaking out of lists and such.

In the above example the leading indentation is 0 spaces until the start of the directive indicator but if you put an admonition inside of a list or something then the number will be higher.

#### Admonition type
Second, it figures out what class to assign the `<aside>`. This is usually `"admonition [TYPE]"` (where `[TYPE]` is attention, tip, warning, etc...) but in the case of generic admonitions the class is just `"admonition"`.
The admonition type is then inserted into the HTML block as bold text.

#### Admonition title
The title is optional. The [docutils RST directives spec](https://docutils.sourceforge.io/docs/ref/rst/directives.html#admonitions) says that titles are required for generic admonitions but I did not enforce this rule.
If the title is present, however, it is inserted in italics.

#### Admonition body
The admonition body is where things get a bit more complicated, however. The aforementioned spec says:
> Any text immediately following the directive indicator ([...] indented on following lines) is interpreted as a directive block and is parsed for normal body elements.

So any text after the directive indicator that is indented by the admonition's leading indentation PLUS 3 spaces or more is considered part of the admonition body. This can continue until EOF, 3 blank lines or something less indented. For example:
```rst
.. tip::
   3 spaces indented, this is part of the body.
    4 spaces indented, this is still part of the body.
0 spaces indented, this is no longer part of the admonition

.. tip::
   3 spaces indented.
  2 spaces indented, this is no longer part of the admonition

.. tip::
   3 spaces indented.



    After 3 blank lines this is no longer part of the admonition even though it is indented.
    This is now an indented code block
```
The body text is processed as normal markdown, meaning you can put pretty much anything in there (lists, tables, other admonitions...).

<br>
I hope that all makes sense and isn't too much of a ramble. If you have any questions or concerns about some of the design decisions made then feel free to ask :)