### PR TITLE
Fix `TypeError` if `html-classes` extra is None #391

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1935,8 +1935,9 @@ class Markdown(object):
         except TypeError:
             return ""
         else:
-            if tag in html_classes_from_tag:
-                return ' class="%s"' % html_classes_from_tag[tag]
+            if isinstance(html_classes_from_tag, dict):
+                if tag in html_classes_from_tag:
+                    return ' class="%s"' % html_classes_from_tag[tag]
         return ""
 
     def _do_code_blocks(self, text):

--- a/test/tm-cases/html_classes_is_none.html
+++ b/test/tm-cases/html_classes_is_none.html
@@ -1,0 +1,2 @@
+<pre><code>print("hello world")
+</code></pre>

--- a/test/tm-cases/html_classes_is_none.opts
+++ b/test/tm-cases/html_classes_is_none.opts
@@ -1,0 +1,1 @@
+{"extras": ["html-classes", "fenced-code-blocks"]}

--- a/test/tm-cases/html_classes_is_none.tags
+++ b/test/tm-cases/html_classes_is_none.tags
@@ -1,0 +1,1 @@
+extras html-classes

--- a/test/tm-cases/html_classes_is_none.text
+++ b/test/tm-cases/html_classes_is_none.text
@@ -1,0 +1,3 @@
+```
+print("hello world")
+```


### PR DESCRIPTION
This PR tweaks the `html-classes` extra so that a TypeError will not be raised if HTML class mappings are not given.
````python
import markdown2

text="""
```
print("hello world")
```
"""

markdown2.markdown(text, extras=["html-classes"])
````

In the above example, no mapping was provided for the extra so the value defaults to `None`. When it gets around to checking if a certain tag is present in the html classes mapping, a type error occurs.

The proposed change simply checks if the html classes extra is an instance of `dict`, and if not it returns an empty string.