### PR TITLE
Fix link patterns extra applying within links (issue #385)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2374,18 +2374,18 @@ class Markdown(object):
                     text = text[:start - 3] + text[start:end] + text[end + 3:]
                     continue
 
-                # Do not match against <http://example.com> style auto links
-                if self._auto_link_re.match(text):
-                    continue
-
                 # search the text for anything that looks like a link
                 is_inside_link = False
-                for match in self._basic_link_re.finditer(text):
-                    if any((r[0] <= start and end <= r[1]) for r in match.regs):
-                        # if the link pattern start and end pos is within the bounds of
-                        # something that looks like a link, then don't process it
-                        is_inside_link = True
-                        break
+                for link_re in (self._auto_link_re, self._basic_link_re):
+                    for match in link_re.finditer(text):
+                        if any((r[0] <= start and end <= r[1]) for r in match.regs):
+                            # if the link pattern start and end pos is within the bounds of
+                            # something that looks like a link, then don't process it
+                            is_inside_link = True
+                            break
+                    else:
+                        continue
+                    break
 
                 if is_inside_link:
                     continue

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2373,6 +2373,10 @@ class Markdown(object):
                     text = text[:start - 3] + text[start:end] + text[end + 3:]
                     continue
 
+                # Do not match against <http://example.com> style auto links
+                if self._auto_link_re.match(text):
+                    continue
+
                 escaped_href = (
                     href.replace('"', '&quot;')  # b/c of attr quote
                         # To avoid markdown <em> and <strong>:

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2348,6 +2348,7 @@ class Markdown(object):
                % (''.join(chars), ''.join(chars[7:]))
         return addr
 
+    _basic_link_re = re.compile(r'!?\[.*?\]\(.*?\)')
     def _do_link_patterns(self, text):
         link_from_hash = {}
         for regex, repl in self.link_patterns:
@@ -2375,6 +2376,18 @@ class Markdown(object):
 
                 # Do not match against <http://example.com> style auto links
                 if self._auto_link_re.match(text):
+                    continue
+
+                # search the text for anything that looks like a link
+                is_inside_link = False
+                for match in self._basic_link_re.finditer(text):
+                    if any((r[0] <= start and end <= r[1]) for r in match.regs):
+                        # if the link pattern start and end pos is within the bounds of
+                        # something that looks like a link, then don't process it
+                        is_inside_link = True
+                        break
+
+                if is_inside_link:
                     continue
 
                 escaped_href = (

--- a/test/tm-cases/link_patterns_edge_cases.html
+++ b/test/tm-cases/link_patterns_edge_cases.html
@@ -1,1 +1,5 @@
 <p><a href="http://foo.com/blah_blah_blah/123">Blah 123</a> becomes a line with two underscores.</p>
+
+<p><a href="http://localhost/#42">http://localhost/#42</a></p>
+
+<p><a href="http://localhost">Issue #42</a></p>

--- a/test/tm-cases/link_patterns_edge_cases.html
+++ b/test/tm-cases/link_patterns_edge_cases.html
@@ -1,5 +1,5 @@
 <p><a href="http://foo.com/blah_blah_blah/123">Blah 123</a> becomes a line with two underscores.</p>
 
-<p><a href="http://localhost/#42">http://localhost/#42</a></p>
+<p><a href="http://localhost/#42">http://localhost/#42</a> with another reference to Issue <a href="http://localhost/issue/42">#42</a> in the same line</p>
 
 <p><a href="http://localhost">Issue #42</a></p>

--- a/test/tm-cases/link_patterns_edge_cases.opts
+++ b/test/tm-cases/link_patterns_edge_cases.opts
@@ -1,6 +1,7 @@
 {"extras": ["link-patterns"],
  "link_patterns": [
     (re.compile("Blah\s+(\d+)", re.I), r"http://foo.com/blah_blah_blah/\1"),
+    (re.compile("#([1-9][0-9]*)"), r"http://localhost/issue/\1"),
  ],
 }
 

--- a/test/tm-cases/link_patterns_edge_cases.text
+++ b/test/tm-cases/link_patterns_edge_cases.text
@@ -1,5 +1,5 @@
 Blah 123 becomes a line with two underscores.
 
-<http://localhost/#42>
+<http://localhost/#42> with another reference to Issue #42 in the same line
 
 [Issue #42](http://localhost)

--- a/test/tm-cases/link_patterns_edge_cases.text
+++ b/test/tm-cases/link_patterns_edge_cases.text
@@ -1,1 +1,5 @@
 Blah 123 becomes a line with two underscores.
+
+<http://localhost/#42>
+
+[Issue #42](http://localhost)


### PR DESCRIPTION
Fixed link patterns extra applying to patterns that are already inside an auto link or a markdown link.
EG:
```python
import markdown2, re
patterns = [(re.compile(r'#([1-9][0-9]*)'), r'http://localhost/issue/\1')]
m = markdown2.Markdown(extras=['link-patterns'], link_patterns=patterns)
print(m.convert("""
<http://localhost/#42>

[Issue #42](http://localhost)
"""))
```
As demonstrated in #385, this would previously produce the output:
```html
<p><http://localhost/<a href="http://localhost/issue/42">#42</a>&gt;</p>

<p><a href="http://localhost/">Issue <a href="http://localhost/issue/42">#42</a></a></p>
```
But now should produce:
```html
<p><a href="http://localhost/#42">http://localhost/#42</a></p>

<p><a href="http://localhost/">Issue #42</a></p>
```

The fix works by searching for anything that looks like a markdown link or an auto link within the text. It then checks that the matched link pattern is not within the start and end of the matched markdown/auto link before processing it.