### PR TITLE
Codespans inside link text issue344

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1976,8 +1976,17 @@ class Markdown(object):
 
     def _code_span_sub(self, match):
         c = match.group(2).strip(" \t")
-        c = self._encode_code(c)
-        return "<code>%s</code>" % c
+
+        if not self.safe_mode:
+            c = self._encode_code(c)
+
+        c = "<code>%s</code>" % c
+
+        if self.safe_mode:
+            key = _hash_text(c)
+            self.html_spans[key] = c
+            return key
+        return c
 
     def _do_code_spans(self, text):
         #   *   Backtick quotes are used for <code></code> spans.

--- a/test/tm-cases/codespans_inside_link_text.html
+++ b/test/tm-cases/codespans_inside_link_text.html
@@ -1,0 +1,3 @@
+<p><a href="https://example.com"><code>example</code></a></p>
+
+<p><a href="https://example.com">more <code>examples</code></a></p>

--- a/test/tm-cases/codespans_inside_link_text.text
+++ b/test/tm-cases/codespans_inside_link_text.text
@@ -1,0 +1,3 @@
+[`example`](https://example.com)
+
+[more `examples`](https://example.com)


### PR DESCRIPTION
This PR fixes issue #344, where back-ticks would not work within links.
The solution works by ignoring encoded code spans in `_hash_html_spans`