### PR TITLE
Fix emacs local variable one-liners

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -259,6 +259,10 @@ class Markdown(object):
         self.html_spans = {}
         self.list_level = 0
         self.extras = self._instance_extras.copy()
+        self._setup_extras()
+        self._toc = None
+
+    def _setup_extras(self):
         if "footnotes" in self.extras:
             self.footnotes = {}
             self.footnote_ids = []
@@ -266,7 +270,6 @@ class Markdown(object):
             self._count_from_header_id = defaultdict(int)
         if "metadata" in self.extras:
             self.metadata = {}
-        self._toc = None
 
     # Per <https://developer.mozilla.org/en-US/docs/HTML/Element/a> "rel"
     # should only be used in <a> tags with an "href" attribute.
@@ -318,6 +321,8 @@ class Markdown(object):
                     else:
                         ename, earg = e, None
                     self.extras[ename] = earg
+
+            self._setup_extras()
 
         # Standardize line endings:
         text = text.replace("\r\n", "\n")

--- a/test/tm-cases/emacs_file_vars.html
+++ b/test/tm-cases/emacs_file_vars.html
@@ -1,0 +1,6 @@
+<!-- -*- markdown-extras: footnotes -*- -->
+
+<p>This markdown text will be converted with the "footnotes"
+extra enabled.</p>
+
+<p>This test should not raise any errors</p>

--- a/test/tm-cases/emacs_file_vars.opts
+++ b/test/tm-cases/emacs_file_vars.opts
@@ -1,0 +1,1 @@
+{"use_file_vars": True}

--- a/test/tm-cases/emacs_file_vars.text
+++ b/test/tm-cases/emacs_file_vars.text
@@ -1,0 +1,6 @@
+-*- markdown-extras: footnotes -*-
+
+This markdown text will be converted with the "footnotes"
+extra enabled.
+
+This test should not raise any errors


### PR DESCRIPTION
This PR fixes a couple of issues.

**Issue 1:** `AttributeError` being raised when specifying some extras via emacs local variables
```python
> import markdown2
> text = "-*- markdown-extras: footnotes -*-\nRandom unimportant text"
> markdown2.markdown(text, use_file_vars=True)
AttributeError: 'Markdown' object has no attribute 'footnotes'
```
This error happened because the `self.footnotes` dictionary is created by the `self.reset()` function, which is called BEFORE the emacs local variables get parsed. This means that the `self.footnotes` dictionary doesn't get created because, when it is called, the footnotes extra has not been specified.
This PR puts the `self.footnotes` dict creation (and some other extras setup) into a separate `_setup_extras` function which gets called during `self.reset()` and after the emacs local variables are parsed.

**Issue 2:** Emacs local variables appearing in the HTML output  

Previously, an emacs one-liner would be parsed but have no changes made to it, meaning that it would appear in the final HTML.
```python
> import markdown2
> text = "-*- markdown-extras: footnotes -*-\nRandom unimportant text"
> print(markdown2.markdown(text, use_file_vars=True))
<p>-<em>- markdown-extras: footnotes -</em>-</p>
<p>Random unimportant text</p>
```
This PR changes this so that these one-liners get automatically wrapped in HTML comments, so the output looks more like this:
```html
<!-- -*- markdown-extras: footnotes -*- -->
<p>Random unimportant text</p>
```