### PR TITLE
Fix code block indentation in lists

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1886,6 +1886,9 @@ class Markdown(object):
                 codeblock = rest.lstrip("\n")   # Remove lexer declaration line.
                 formatter_opts = self.extras['code-color'] or {}
 
+        # remove leading indent from code block
+        leading_indent, codeblock = self._uniform_outdent(codeblock)
+
         # Use pygments only if not using the highlightjs-lang extra
         if lexer_name and "highlightjs-lang" not in self.extras:
             def unhash_code(codeblock):
@@ -1901,8 +1904,6 @@ class Markdown(object):
                 return codeblock
             lexer = self._get_pygments_lexer(lexer_name)
             if lexer:
-                # remove leading indent from code block
-                leading_indent, codeblock = self._uniform_outdent(codeblock)
 
                 codeblock = unhash_code( codeblock )
                 colored = self._color_with_pygments(codeblock, lexer,
@@ -1919,8 +1920,8 @@ class Markdown(object):
         else:
             code_class_str = self._html_class_str_from_tag("code")
 
-        return "\n<pre%s><code%s>%s\n</code></pre>\n" % (
-            pre_class_str, code_class_str, codeblock)
+        return "\n%s<pre%s><code%s>%s\n</code></pre>\n" % (
+            leading_indent, pre_class_str, code_class_str, codeblock)
 
     def _html_class_str_from_tag(self, tag):
         """Get the appropriate ' class="..."' string (note the leading

--- a/test/tm-cases/issue276_fenced_code_blocks_in_lists.html
+++ b/test/tm-cases/issue276_fenced_code_blocks_in_lists.html
@@ -1,0 +1,14 @@
+<ol>
+<li><p>This is my first list item</p>
+
+<pre><code>And this is my code item
+</code></pre>
+
+<p>Followed by another paragraph</p></li>
+<li><p>This is my second list item</p>
+
+<pre><code>
+</code></pre>
+
+<p>empty codeblock just for sh*ts and giggles</p></li>
+</ol>

--- a/test/tm-cases/issue276_fenced_code_blocks_in_lists.html
+++ b/test/tm-cases/issue276_fenced_code_blocks_in_lists.html
@@ -10,5 +10,12 @@
 <pre><code>
 </code></pre>
 
-<p>empty codeblock just for sh*ts and giggles</p></li>
+<p>empty codeblock just for sh*ts and giggles</p>
+
+<div class="codehilite"><pre><span></span><code><span class="n">test</span> <span class="k">with</span> <span class="n">language</span> <span class="nb">set</span>
+</code></pre></div>
+
+<pre><code>This is a regular code block
+Multiline
+</code></pre></li>
 </ol>

--- a/test/tm-cases/issue276_fenced_code_blocks_in_lists.opts
+++ b/test/tm-cases/issue276_fenced_code_blocks_in_lists.opts
@@ -1,0 +1,1 @@
+{"extras": ["fenced-code-blocks"]}

--- a/test/tm-cases/issue276_fenced_code_blocks_in_lists.tags
+++ b/test/tm-cases/issue276_fenced_code_blocks_in_lists.tags
@@ -1,0 +1,1 @@
+extra fenced-code-blocks pygments

--- a/test/tm-cases/issue276_fenced_code_blocks_in_lists.text
+++ b/test/tm-cases/issue276_fenced_code_blocks_in_lists.text
@@ -12,3 +12,10 @@
     ```
 
     empty codeblock just for sh\*ts and giggles
+
+    ```python
+    test with language set
+    ```
+
+        This is a regular code block
+        Multiline

--- a/test/tm-cases/issue276_fenced_code_blocks_in_lists.text
+++ b/test/tm-cases/issue276_fenced_code_blocks_in_lists.text
@@ -1,0 +1,14 @@
+1. This is my first list item
+
+    ```
+    And this is my code item
+    ```
+
+    Followed by another paragraph
+
+2. This is my second list item
+
+    ```
+    ```
+
+    empty codeblock just for sh\*ts and giggles


### PR DESCRIPTION
This is a fix for issue #276. There's a failure in converting markdown lists that have fenced code blocks in them, because the indentation of the fenced code block is not accounted for unless syntax highlighting is enabled.

I also pulled out the code for substituting code blocks with a lexer into its own method so it is a little easier to read.