### PR TITLE
Fix multilevel lists

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1798,7 +1798,7 @@ class Markdown(object):
             item = self._run_block_gamut(self._outdent(item))
         else:
             # Recursion for sub-lists:
-            item = self._do_lists(self._outdent(item))
+            item = self._do_lists(self._uniform_outdent(item, min_outdent=' ')[1])
             if item.endswith('\n'):
                 item = item[:-1]
             item = self._run_span_gamut(item)
@@ -2457,12 +2457,19 @@ class Markdown(object):
         # Remove one level of line-leading tabs or spaces
         return self._outdent_re.sub('', text)
 
-    def _uniform_outdent(self, text):
+    def _uniform_outdent(self, text, min_outdent=None):
         # Removes the smallest common leading indentation from each line
         # of `text` and returns said indent along with the outdented text.
+        # The `min_outdent` kwarg only outdents lines that start with at
+        # least this level of indentation or more.
 
         # Find leading indentation of each line
         ws = re.findall(r'(^[ \t]*)(?:[^ \t\n])', text, re.MULTILINE)
+        # Sort the indents within bounds
+        if min_outdent:
+            # dont use "is not None" here so we avoid iterating over ws
+            # if min_outdent == '', which would do nothing
+            ws = [i for i in ws if len(min_outdent) <= len(i)]
         if not ws:
             return '', text
         # Get smallest common leading indent

--- a/test/tm-cases/admonitions.html
+++ b/test/tm-cases/admonitions.html
@@ -45,8 +45,8 @@ print('an indented code block right after')
         <ul>
         <li>Even inside
         <aside class="admonition tip">
-          <strong>tip</strong>
-          <p>of a list</p>
+            <strong>tip</strong>
+            <p>of a list</p>
         </aside></li>
         </ul>
     </aside>

--- a/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.html
+++ b/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.html
@@ -3,14 +3,18 @@
 <ul>
 <li>O que é estrutura Co-locada (on premises), o que é estrutura híbrida e o que é estrutura em-nuvem?
 <ul>
-<li>Em Nuvem (cloud based)</li>
+<li>Em Nuvem (cloud based)
+<ul>
 <li>Uma estrutura em-nuvem tem todos os seus principais recursos providos por um provedor de serviços em nuvem.
 <ul>
-<li>Uma definição formal de serviço em nuvem pode ser:</li>
+<li>Uma definição formal de serviço em nuvem pode ser:
+<ul>
 <li>Entrega via internet de um serviço de Tecnologia da Informação, sob demanda, em um modelo de pague-pelo-que-consome.
 <ul>
 <li>Brown Field é quando você migra um serviço existente</li>
 <li>Green field é quando você começa do zero na nuvem, alguns também chamam isto de Cloud </li>
+</ul></li>
+</ul></li>
 </ul></li>
 </ul></li>
 </ul></li>

--- a/test/tm-cases/nested_list.html
+++ b/test/tm-cases/nested_list.html
@@ -13,3 +13,24 @@
 <li><em>peaches</em></li>
 </ul></li>
 </ul>
+
+<p>Slightly more nested list:</p>
+
+<ul>
+<li>Item 1
+<ol>
+<li>Hello</li>
+<li>World</li>
+</ol></li>
+<li>Item 2
+<ul>
+<li>Subitem A</li>
+<li>Subitem B following:
+<ul>
+<li>What</li>
+<li>The</li>
+<li>Code</li>
+</ul></li>
+</ul></li>
+<li>Item 3 - yes! just a single item</li>
+</ul>

--- a/test/tm-cases/nested_list.text
+++ b/test/tm-cases/nested_list.text
@@ -7,3 +7,17 @@ shopping list:
     + oranges
     + apples
     + *peaches*
+
+
+Slightly more nested list:
+
+* Item 1
+  1. Hello
+  2. World
+* Item 2
+  - Subitem A
+  - Subitem B following:
+    + What
+    + The
+    + Code
+* Item 3 - yes! just a single item


### PR DESCRIPTION
This PR fixes #275. The issue was that lists with multiple levels of nesting were being flattened. For example:
```markdown
* Item 2
  - Subitem B following:
    + What
    + The
    + Code
```
Would become:
![image](https://user-images.githubusercontent.com/57498990/183650630-1986f40b-4c71-4503-9778-f54c257cffbf.png)
Which is obviously wrong. The bug came from the following line in the `_list_item_sub` function:
https://github.com/trentm/python-markdown2/blob/6032f8b5f95f579e0fc73c15ef7eaf6925e771bf/lib/markdown2.py#L1801
Once the above example reaches this line it is then outdented to:
```markdown
Item 2
- Subitem B following:
+ What
+ The
+ Code
```
Which now just resembles a normal list and will be processed as such.
This PR changes the `_list_item_sub` function to use the `_uniform_outdent` function, which produces the following output at the same point in the program, allowing nesting to be preserved.
```markdown
Item 2
- Subitem B following:
  + What
  + The
  + Code
```

Whilst working on this bug I also discovered that the [break_on_newline_excessive_br_tags test case](https://github.com/Crozzers/python-markdown2/blob/915b567875ea32c6f45a5d4ebdb16f29d93d042a/test/tm-cases/break_on_newline_excessive_br_tags_in_ul.text), added in PR #422, contained incorrect list nesting.
![image](https://user-images.githubusercontent.com/57498990/183678080-973593c5-0da0-4b65-9c6e-8894d8742800.png)
This PR also fixes that test case.