### PR TITLE
Fix `html-classes` extra not applying to code spans

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2021,7 +2021,7 @@ class Markdown(object):
     def _code_span_sub(self, match):
         c = match.group(2).strip(" \t")
         c = self._encode_code(c)
-        return "<code>%s</code>" % c
+        return "<code%s>%s</code>" % (self._html_class_str_from_tag("code"), c)
 
     def _do_code_spans(self, text):
         #   *   Backtick quotes are used for <code></code> spans.

--- a/test/tm-cases/html_classes.html
+++ b/test/tm-cases/html_classes.html
@@ -7,7 +7,7 @@
 </thead>
 <tbody>
 <tr>
-  <td><code>Cell 1</code></td>
+  <td><code class="codesyntaxcolor">Cell 1</code></td>
   <td><a href="http://example.com">Cell 2</a> link</td>
 </tr>
 <tr>


### PR DESCRIPTION
The `html-classes` extra says it supports code tags but previously this was only applied to fenced code blocks when using the `fenced-code-blocks` extra. This PR modifies the `_code_span_sub` function to fix this omission and also updates the relevant test case.