### PR TITLE
Add optional dependencies to `setup.py`

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install Pygments>=2.5.2
+          pip install .[all]
       - name: Test
         run: |
           make testone

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - [pull #455] Fix code block indentation in lists
 - [pull #434] Fix filter bypass leading to XSS (#362)
 - [pull #464] Fix html-classes extra not applying to code spans
+- [pull #466] Add optional dependencies to `setup.py`
 
 
 ## python-markdown2 2.4.3

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ for updates to python-markdown2.
 To install it in your Python installation run *one* of the following:
 
     pip install markdown2
+    pip install markdown2[all]  # to install all optional dependencies (eg: Pygments for code syntax highlighting)
     pypm install markdown2      # if you use ActivePython (activestate.com/activepython)
     easy_install markdown2      # if this is the best you have
     python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,12 @@ Topic :: Text Processing :: Filters
 Topic :: Text Processing :: Markup :: HTML
 """
 
+extras_require = {
+    "code_syntax_highlighting": ["pygments>=2.7.3"]
+}
+# nested listcomp to combine all optional extras into convenient "all" option
+extras_require["all"] = [i for v in tuple(extras_require.values()) for i in v]
+
 setup(
     name="markdown2",
     version=markdown2.__version__,
@@ -49,6 +55,7 @@ setup(
     },
     description="A fast and complete Python implementation of Markdown",
     python_requires=">=3.5, <4",
+    extras_require=extras_require,
     classifiers=classifiers.strip().split("\n"),
     long_description="""markdown2: A fast and complete Python implementation of Markdown.
 


### PR DESCRIPTION
Previously, if a user wanted to make sure optional features of markdown2 (such as code syntax highlighting) were enabled and working, they would have to know to install the optional dependencies (EG: Pygments) for these features to work.
This PR adds the `extras_require` key to `setup.py` to define these optional dependencies, enabling users to do:
```
pip install markdown2[code_syntax_highlighting]
```
To install markdown2 as well as Pygments>=2.7.3 (the earliest version I found that still passes all tests) for code highlighting.

I also added an "all" extra that automatically combines all the other extras to allow a short, convenient and easily memorable way to make sure all optional dependencies are installed.
```
pip install markdown2[all]
```
