### PR TITLE
Add support for ordered lists that don't start at 1. (issue #469)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 - [pull #462] Fix pygments block matching
 - [pull #462] Fix pyshell blocks in blockquotes
 - [pull #463] Fix multilevel lists
+- [pull #470] Add support for ordered lists that don't start at 1. (#469)
 
 
 ## python-markdown2 2.4.3

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1707,11 +1707,18 @@ class Markdown(object):
     def _list_sub(self, match):
         lst = match.group(1)
         lst_type = match.group(3) in self._marker_ul_chars and "ul" or "ol"
+
+        if lst_type == 'ol' and match.group(3) != '1.':
+            # if list doesn't start at 1 then set the ol start attribute
+            lst_opts = ' start="%s"' % match.group(3)[:-1]
+        else:
+            lst_opts = ''
+
         result = self._process_list_items(lst)
         if self.list_level:
-            return "<%s>\n%s</%s>\n" % (lst_type, result, lst_type)
+            return "<%s%s>\n%s</%s>\n" % (lst_type, lst_opts, result, lst_type)
         else:
-            return "<%s>\n%s</%s>\n\n" % (lst_type, result, lst_type)
+            return "<%s%s>\n%s</%s>\n\n" % (lst_type, lst_opts, result, lst_type)
 
     def _do_lists(self, text):
         # Form HTML ordered (numbered) and unordered (bulleted) lists.

--- a/test/tm-cases/ordered_list_lazy_numbering.html
+++ b/test/tm-cases/ordered_list_lazy_numbering.html
@@ -1,0 +1,25 @@
+<p>Example 1:</p>
+
+<ol>
+<li>Most ordered lists</li>
+<li>Start at number one</li>
+<li>And go up from there</li>
+</ol>
+
+<p>Example 2:</p>
+
+<ol start="2">
+<li>Some lists might start from 2</li>
+<li>And continue from there</li>
+</ol>
+
+<p>Example 3:</p>
+
+<ol start="999">
+<li>What about 999</li>
+<li>And going to a thousand
+<ol start="7">
+<li>With some nested offset ordered lists</li>
+<li>Just for good measure</li>
+</ol></li>
+</ol>

--- a/test/tm-cases/ordered_list_lazy_numbering.text
+++ b/test/tm-cases/ordered_list_lazy_numbering.text
@@ -1,0 +1,17 @@
+Example 1:
+
+1. Most ordered lists
+2. Start at number one
+3. And go up from there
+
+Example 2:
+
+2. Some lists might start from 2
+3. And continue from there
+
+Example 3:
+
+999. What about 999
+1000. And going to a thousand
+  7. With some nested offset ordered lists
+  8. Just for good measure


### PR DESCRIPTION
This PR closes #469 by adding support for ordered lists that don't start at 1, making use of the "start" attribute for `<ol>` tags.
Example input:
```markdown
2. Item 1
3. Item 2
```
Previous output:
```html
<ol>
<li>Item 1</li>
<li>Item 2</li>
</ol>
```
New output:
```html
<ol start="2">
<li>Item 1</li>
<li>Item 2</li>
</ol>
```