### PR TITLE
Fix `AssertionError` with lazy numbered lists (issue #471)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 - [pull #462] Fix pyshell blocks in blockquotes
 - [pull #463] Fix multilevel lists
 - [pull #470] Add support for ordered lists that don't start at 1. (#469)
+- [pull #472] Fix `AssertionError` with lazy numbered lists (issue #471)
 
 
 ## python-markdown2 2.4.3

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2272,7 +2272,7 @@ class Markdown(object):
                     ):
                         start = li.start()
                         cuddled_list = self._do_lists(graf[start:]).rstrip("\n")
-                        assert cuddled_list.startswith("<ul>") or cuddled_list.startswith("<ol>")
+                        assert re.match(r'^<(?:ul|ol).*?>', cuddled_list)
                         graf = graf[:start]
 
                 # Wrap <p> tags.

--- a/test/tm-cases/ordered_list_lazy_numbering_issue471.html
+++ b/test/tm-cases/ordered_list_lazy_numbering_issue471.html
@@ -1,0 +1,69 @@
+<p>This command performs an entire mail transaction.</p>
+
+<p>The arguments are:
+    - from<em>addr    : The address sending this mail.
+    - to</em>addrs     : A list of addresses to send this mail to.  A bare
+                     string will be treated as a list with 1 address.
+    - msg          : The message to send.
+    - mail<em>options : List of ESMTP options (such as 8bitmime) for the
+                     mail command.
+    - rcpt</em>options : List of ESMTP options (such as DSN commands) for
+                     all the rcpt commands.</p>
+
+<p>msg may be a string containing characters in the ASCII range, or a byte
+string.  A string is encoded to bytes using the ascii codec, and lone
+\r and \n characters are converted to \r\n characters.</p>
+
+<p>If there has been no previous EHLO or HELO command this session, this
+method tries ESMTP EHLO first.  If the server does ESMTP, message size
+and each of the specified options will be passed to it.  If EHLO
+fails, HELO will be tried and ESMTP options suppressed.</p>
+
+<p>This method will return normally if the mail is accepted for at least
+one recipient.  It returns a dictionary, with one entry for each
+recipient that was refused.  Each entry contains a tuple of the SMTP
+error code and the accompanying error message sent by the server.</p>
+
+<p>This method may raise the following exceptions:</p>
+
+<p>SMTPHeloError          The server didn't reply properly to
+                        the helo greeting.
+ SMTPRecipientsRefused  The server rejected ALL recipients
+                        (no mail was sent).
+ SMTPSenderRefused      The server didn't accept the from<em>addr.
+ SMTPDataError          The server replied with an unexpected
+                        error code (other than a refusal of
+                        a recipient).
+ SMTPNotSupportedError  The mail</em>options parameter includes 'SMTPUTF8'
+                        but the SMTPUTF8 extension is not supported by
+                        the server.</p>
+
+<p>Note: the connection will be open even after an exception is raised.</p>
+
+<p>Example:</p>
+
+<blockquote>
+  <blockquote>
+    <blockquote>
+      <p>import smtplib
+      s=smtplib.SMTP("localhost")
+      tolist=["one@one.org","two@two.org","three@three.org","four@four.org"]
+      msg = '''\
+       ... From: Me@my.org
+       ... Subject: testin'...
+       ...
+       ... This is a test '''
+      s.sendmail("me@my.org",tolist,msg)
+       { "three@three.org" : ( 550 ,"User unknown" ) }
+      s.quit()</p>
+    </blockquote>
+  </blockquote>
+</blockquote>
+
+<p>In the above example, the message was accepted for delivery to three
+of the four addresses, and one was rejected, with the error code</p>
+
+<ol start="550">
+<li>If all addresses are accepted, then the method will return an
+empty dictionary.</li>
+</ol>

--- a/test/tm-cases/ordered_list_lazy_numbering_issue471.opts
+++ b/test/tm-cases/ordered_list_lazy_numbering_issue471.opts
@@ -1,0 +1,1 @@
+{"extras": ["cuddled-lists"]}

--- a/test/tm-cases/ordered_list_lazy_numbering_issue471.text
+++ b/test/tm-cases/ordered_list_lazy_numbering_issue471.text
@@ -1,0 +1,60 @@
+This command performs an entire mail transaction.
+
+The arguments are:
+    - from_addr    : The address sending this mail.
+    - to_addrs     : A list of addresses to send this mail to.  A bare
+                     string will be treated as a list with 1 address.
+    - msg          : The message to send.
+    - mail_options : List of ESMTP options (such as 8bitmime) for the
+                     mail command.
+    - rcpt_options : List of ESMTP options (such as DSN commands) for
+                     all the rcpt commands.
+
+msg may be a string containing characters in the ASCII range, or a byte
+string.  A string is encoded to bytes using the ascii codec, and lone
+\r and \n characters are converted to \r\n characters.
+
+If there has been no previous EHLO or HELO command this session, this
+method tries ESMTP EHLO first.  If the server does ESMTP, message size
+and each of the specified options will be passed to it.  If EHLO
+fails, HELO will be tried and ESMTP options suppressed.
+
+This method will return normally if the mail is accepted for at least
+one recipient.  It returns a dictionary, with one entry for each
+recipient that was refused.  Each entry contains a tuple of the SMTP
+error code and the accompanying error message sent by the server.
+
+This method may raise the following exceptions:
+
+ SMTPHeloError          The server didn't reply properly to
+                        the helo greeting.
+ SMTPRecipientsRefused  The server rejected ALL recipients
+                        (no mail was sent).
+ SMTPSenderRefused      The server didn't accept the from_addr.
+ SMTPDataError          The server replied with an unexpected
+                        error code (other than a refusal of
+                        a recipient).
+ SMTPNotSupportedError  The mail_options parameter includes 'SMTPUTF8'
+                        but the SMTPUTF8 extension is not supported by
+                        the server.
+
+Note: the connection will be open even after an exception is raised.
+
+Example:
+
+ >>> import smtplib
+ >>> s=smtplib.SMTP("localhost")
+ >>> tolist=["one@one.org","two@two.org","three@three.org","four@four.org"]
+ >>> msg = '''\
+ ... From: Me@my.org
+ ... Subject: testin'...
+ ...
+ ... This is a test '''
+ >>> s.sendmail("me@my.org",tolist,msg)
+ { "three@three.org" : ( 550 ,"User unknown" ) }
+ >>> s.quit()
+
+In the above example, the message was accepted for delivery to three
+of the four addresses, and one was rejected, with the error code
+550.  If all addresses are accepted, then the method will return an
+empty dictionary.


### PR DESCRIPTION
This PR fixes #471.

The issue was with an assertion that ordered lists must start with `<ol>` which, since c3d4e41, may no longer be the case. This PR updates that assertion to match `r'^<(?:ul|ol).*?>'` which should allow for list tags with attributes.