### PR TITLE
Add test for nested incomplete tag sanitization

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2356,7 +2356,10 @@ class Markdown(object):
         if text.endswith(">"):
             return text  # this is not an incomplete tag, this is a link in the form <http://x.y.z>
 
-        return self._incomplete_tags_re.sub("&lt;\\1", text)
+        def incomplete_tags_sub(match):
+            return match.group().replace('<', '&lt;')
+
+        return self._incomplete_tags_re.sub(incomplete_tags_sub, text)
 
     def _encode_backslash_escapes(self, text):
         for ch, escape in list(self._escape_table.items()):

--- a/test/tm-cases/nested_incomplete_tags_xss.html
+++ b/test/tm-cases/nested_incomplete_tags_xss.html
@@ -1,7 +1,7 @@
-<p>&lt;img &lt;img src="" onerror=alert(/XSS/) </p>
+<p>&lt;img &lt;img src="" onerror=alert(/XSS/)</p>
 
-<p>&lt;img&lt;img src="" onerror=alert(/XSS/) </p>
+<p>&lt;img&lt;img src="" onerror=alert(/XSS/)</p>
 
-<p>&lt;img&lt;img/src="" onerror=alert(/XSS/) </p>
+<p>&lt;img&lt;img/src="" onerror=alert(/XSS/)</p>
 
-<p>&lt;img&lt;img&lt;img src="" onerror=alert(/XSS/) </p>
+<p>&lt;img&lt;img&lt;img src="" onerror=alert(/XSS/)</p>

--- a/test/tm-cases/nested_incomplete_tags_xss.html
+++ b/test/tm-cases/nested_incomplete_tags_xss.html
@@ -1,0 +1,7 @@
+<p>&lt;img &lt;img src="" onerror=alert(/XSS/) </p>
+
+<p>&lt;img&lt;img src="" onerror=alert(/XSS/) </p>
+
+<p>&lt;img&lt;img/src="" onerror=alert(/XSS/) </p>
+
+<p>&lt;img&lt;img&lt;img src="" onerror=alert(/XSS/) </p>

--- a/test/tm-cases/nested_incomplete_tags_xss.opts
+++ b/test/tm-cases/nested_incomplete_tags_xss.opts
@@ -1,0 +1,1 @@
+{"safe_mode": "replace"}

--- a/test/tm-cases/nested_incomplete_tags_xss.text
+++ b/test/tm-cases/nested_incomplete_tags_xss.text
@@ -1,0 +1,7 @@
+<img <img src="" onerror=alert(/XSS/)
+
+<img<img src="" onerror=alert(/XSS/)
+
+<img<img/src="" onerror=alert(/XSS/)
+
+<img<img<img src="" onerror=alert(/XSS/)


### PR DESCRIPTION
Hi, this is just a test demonstrating nested incomplete tags resulting in XSS. As there. have been multiple bypasses since I reported https://github.com/trentm/python-markdown2/issues/285, I still think introducing Bleach might be worthwhile. Perhaps in a major version as it might involve breaking changes for rendering. Bleach is a bit more aggressive than current implementation for escaping and replacing in markdown2.

```
>>> bleach.clean('<blah/<img src="" onerror=alert(/XSS/)')
''
```