### PR TITLE
Fix mixing ordered and un-ordered lists combining into single list type.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## python-markdown2 2.4.6 (not yet released)
 
 - [pull #477] Feature wavedrom support
+- [pull #480] Fix mixing ordered and un-ordered lists combining into single list type
 
 
 ## python-markdown2 2.4.5

--- a/test/tm-cases/mix-ordered-and-unordered-lists.html
+++ b/test/tm-cases/mix-ordered-and-unordered-lists.html
@@ -1,0 +1,23 @@
+<ol>
+<li>Test:</li>
+<li>Lorem Ipsum</li>
+</ol>
+
+<ul>
+<li>Lorem Ipsum</li>
+<li>Lorem Ipsum</li>
+<li>Lorem Ipsum</li>
+</ul>
+
+<p>And another one</p>
+
+<ol>
+<li>Test: 
+Lorem Ipsum</li>
+</ol>
+
+<ul>
+<li>Lorem Ipsum</li>
+<li>Lorem Ipsum</li>
+<li>Lorem Ipsum</li>
+</ul>

--- a/test/tm-cases/mix-ordered-and-unordered-lists.text
+++ b/test/tm-cases/mix-ordered-and-unordered-lists.text
@@ -1,0 +1,15 @@
+1. Test:
+2. Lorem Ipsum
+- Lorem Ipsum
+- Lorem Ipsum
+- Lorem Ipsum
+
+
+And another one
+
+
+1. Test: 
+Lorem Ipsum
+- Lorem Ipsum
+- Lorem Ipsum
+- Lorem Ipsum


### PR DESCRIPTION
This PR fixes #478.

The issue was, as described in #478, mixing ordered and unordered lists like so:
```markdown
1. Lorem Ipsum
2. Lorem Ipsum
- Lorem Ipsum
- Lorem Ipsum
```
Which would produce:
```html
<ol>
<li>Lorem Ipsum</li>
<li>Lorem Ipsum</li>
<li>Lorem Ipsum</li>
<li>Lorem Ipsum</li>
</ol>
```
Which completely ignores the fact that the list type changes halfway down. This PR updates the list regex in `_do_lists` to check for a change of list type to produce the following output:
```html
<ol>
<li>Lorem Ipsum</li>
<li>Lorem Ipsum</li>
</ol>

<ul>
<li>Lorem Ipsum</li>
<li>Lorem Ipsum</li>
</ul>
```