### PR TITLE
Fix hashing nested HTML blocks

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -882,23 +882,20 @@ class Markdown(object):
         result = ''
 
         for chunk in text.splitlines(True):
-            is_markup = re.match(r'^(</?(%s)\b>?)' % current_tag, chunk)
+            is_markup = re.match(r'^(?:</code>(?=</pre>))?(</?(%s)\b>?)' % current_tag, chunk)
             block += chunk
 
             if is_markup:
-                if is_markup.group(2) == 'pre':
-                    is_markup = None
+                if chunk.startswith('</'):
+                    tag_count -= 1
                 else:
-                    if chunk.startswith('</'):
-                        tag_count -= 1
+                    # if close tag is in same line
+                    if '</%s>' % is_markup.group(2) in chunk[is_markup.end():]:
+                        # we must ignore these
+                        is_markup = None
                     else:
-                        # if close tag is in same line
-                        if '</%s>' % is_markup.group(2) in chunk[is_markup.end():]:
-                            # we must ignore these
-                            is_markup = None
-                        else:
-                            tag_count += 1
-                            current_tag = is_markup.group(2)
+                        tag_count += 1
+                        current_tag = is_markup.group(2)
 
             if tag_count == 0:
                 if is_markup:

--- a/test/tm-cases/hash_nested_html_blocks.html
+++ b/test/tm-cases/hash_nested_html_blocks.html
@@ -1,0 +1,7 @@
+<div class="enclosing">
+<div class="codehilite">
+<pre><span></span><code><span class="n">x</span> <span class="o">=</span> <span class="mi">1</span>
+</code></pre>
+</div>
+
+</div>

--- a/test/tm-cases/hash_nested_html_blocks.opts
+++ b/test/tm-cases/hash_nested_html_blocks.opts
@@ -1,0 +1,1 @@
+{"extras": ["fenced-code-blocks", "pygments"]}

--- a/test/tm-cases/hash_nested_html_blocks.tags
+++ b/test/tm-cases/hash_nested_html_blocks.tags
@@ -1,0 +1,1 @@
+extra fenced-code-blocks pygments

--- a/test/tm-cases/hash_nested_html_blocks.text
+++ b/test/tm-cases/hash_nested_html_blocks.text
@@ -1,0 +1,5 @@
+<div class="enclosing">
+```python
+x = 1
+```
+</div>

--- a/test/tm-cases/sublist-para.html
+++ b/test/tm-cases/sublist-para.html
@@ -11,7 +11,7 @@
 <li>Add Komodo chrome (XUL, JavaScript, CSS, DTDs).</li>
 </ul>
 
-<p><p>What this means is that work on and add significant functionality...</p></li>
+<p>What this means is that work on and add significant functionality...</p></li>
 <li><p>Komodo uses the same extension mechanisms as Firefox...</p></li>
 <li><p>Komodo builds and runs on Windows, Linux and ...</p></li>
-</ul></p>
+</ul>


### PR DESCRIPTION
This PR fixes #481 by fixing `_hash_html_blocks` matching the wrong HTML closing tag when hashing HTML blocks.

An example like this:
```html
<div class="enclosing">
<div class="codehilite">
<pre><span></span><code><span class="n">x</span> <span class="o">=</span> <span class="mi">1</span>
</code></pre>
</div>

</div>
```
Would end up with the final closing `</div>` tag wrapped in `<p>` tags as the `_strict_block_tag_re` failed to match against the whole `<div>` block correctly.

This fix solves this issue by iterating over the given text and manually tallying up the number of opening and closing `<div>` tags and then hashing the relevant block.