### PR TITLE
Slight refactor of the `_meta_data_pattern` regex

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -449,17 +449,17 @@ class Markdown(object):
     #
     #   # header
     _meta_data_pattern = re.compile(r'''
-        ^(?:---[\ \t]*\n)?(  # optional opening fence
+        ^{0}(  # optional opening fence
             (?:
-                [\S \t]*\w[\S \t]*\s*:(?:\n+[ \t]+.*)+  # indented lists
+                {1}:(?:\n+[ \t]+.*)+  # indented lists
             )|(?:
-                (?:[\S \t]*\w[\S \t]*\s*:\s+>(?:\n\s+.*)+?)  # multiline long descriptions
-                (?=\n[\S \t]*\w[\S \t]*\s*:\s*.*\n|\s*\Z)  # match up until the start of the next key:value definition or the end of the input text
+                (?:{1}:\s+>(?:\n\s+.*)+?)  # multiline long descriptions
+                (?=\n{1}:\s*.*\n|\s*\Z)  # match up until the start of the next key:value definition or the end of the input text
             )|(?:
-                [\S \t]*\w[\S \t]*\s*:(?! >).*\n?  # simple key:value pair, leading spaces allowed
+                {1}:(?! >).*\n?  # simple key:value pair, leading spaces allowed
             )
-        )(?:---[\ \t]*\n)?  # optional closing fence
-        ''', re.MULTILINE | re.VERBOSE
+        ){0}  # optional closing fence
+        '''.format(r'(?:---[\ \t]*\n)?', r'[\S \t]*\w[\S \t]*\s*'), re.MULTILINE | re.VERBOSE
     )
 
     _key_val_list_pat = re.compile(


### PR DESCRIPTION
This PR is for an ever so slight refactoring of the regular expression used for the markdown metadata extra.

The `_meta_data_pattern` regex is gnarly and awful to look at. This commit makes this a little bit better by using string formatting to substitute in repeated values, such as the definitions for opening fences and metadata keys.

This should reduce repetition and make it easier to change these definitions in the future.