### PR TITLE
Fix backslash being unable to escape raw HTML tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## python-markdown2 2.4.7 (not yet released)
 
 - [pull #483] Fix hashing nested HTML blocks
+- [pull #486] Fix backslash being unable to escape raw HTML tags
 
 
 ## python-markdown2 2.4.6

--- a/test/tm-cases/backslash_escape_html_tags.html
+++ b/test/tm-cases/backslash_escape_html_tags.html
@@ -1,0 +1,13 @@
+<p>this is &lt;strong>some strong&lt;/strong> text</p>
+
+<p><a href="http://localhost/">&lt;strong></a>text&lt;/strong></p>
+
+<p>text \<strong>with double\</strong> escapes</p>
+
+<p>how about text \&lt;strong>with triple\&lt;/strong> escapes</p>
+
+<p>escaped auto-link &lt;https://www.example.com>
+not quite escaped auto link \<a href="https://www.example.com">https://www.example.com</a>
+escaped auto-link \&lt;https://www.example.com></p>
+
+<p>&lt;!-- and escaped HTML comment --> \<!-- followed by one that isn't --> \&lt;!--and another that is--></p>

--- a/test/tm-cases/backslash_escape_html_tags.text
+++ b/test/tm-cases/backslash_escape_html_tags.text
@@ -1,0 +1,13 @@
+this is \<strong>some strong\</strong> text
+
+[\<strong>](http://localhost/)text\</strong>
+
+text \\<strong>with double\\</strong> escapes
+
+how about text \\\<strong>with triple\\\</strong> escapes
+
+escaped auto-link \<https://www.example.com>
+not quite escaped auto link \\<https://www.example.com>
+escaped auto-link \\\<https://www.example.com>
+
+\<!-- and escaped HTML comment --> \\<!-- followed by one that isn't --> \\\<!--and another that is-->


### PR DESCRIPTION
This PR fixes #386, allowing the use of backslashes to escape HTML tags, auto-links and HTML comments.

It works by checking for pairs of backslashes preceding any markup. If there are 0 or more pairs of backslashes (eg: `\\\\`) then they escape themselves. If there is an odd number of backslashes then the markup has been escaped.