### PR TITLE
Fix tests for Pygments 2.14

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -39,10 +39,19 @@ if __name__ == "__main__":
     default_tags = []
     for extra_lib in ('pygments', 'wavedrom'):
         try:
-            importlib.import_module(extra_lib)
+            mod = importlib.import_module(extra_lib)
         except ImportError:
             log.warning("skipping %s tests ('%s' module not found)" % (extra_lib, extra_lib))
             default_tags.append("-%s" % extra_lib)
+        else:
+            if extra_lib == 'pygments':
+                version = tuple(int(i) for i in mod.__version__.split('.')[:3])
+                if version >= (2, 14, 0):
+                    tag = "pygments<2.14"
+                else:
+                    tag = "pygments>=2.14"
+                log.warning("skipping %s tests (pygments %s found)" % (tag, mod.__version__))
+                default_tags.append("-%s" % tag)
 
     retval = testlib.harness(testdir_from_ns=testdir_from_ns,
                              default_tags=default_tags)

--- a/test/tm-cases/fenced_code_blocks_safe_highlight.html
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight.html
@@ -9,8 +9,8 @@ syntax coloring, if <code>pygments</code> is installed. See
 <a href="http://github.github.com/github-flavored-markdown/">http://github.github.com/github-flavored-markdown/</a>.</p>
 
 <div class="codehilite">
-<pre><span></span><code><span class="k">def</span> <span class="nf">foo</span>
-    <span class="nb">puts</span> <span class="s2">&quot;hi&quot;</span>
+<pre><span></span><code><span class="k">def</span><span class="w"> </span><span class="nf">foo</span>
+<span class="w">    </span><span class="nb">puts</span><span class="w"> </span><span class="s2">&quot;hi&quot;</span>
 <span class="k">end</span>
 </code></pre>
 </div>

--- a/test/tm-cases/fenced_code_blocks_safe_highlight.tags
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight.tags
@@ -1,1 +1,1 @@
-extra fenced-code-blocks pygments
+extra fenced-code-blocks pygments pygments>=2.14

--- a/test/tm-cases/fenced_code_blocks_safe_highlight_old.html
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight_old.html
@@ -1,0 +1,16 @@
+<div class="codehilite">
+<pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+    <span class="nb">print</span> <span class="s2">&quot;hi&quot;</span>
+</code></pre>
+</div>
+
+<p>That's using the <em>fenced-code-blocks</em> extra with Python
+syntax coloring, if <code>pygments</code> is installed. See
+<a href="http://github.github.com/github-flavored-markdown/">http://github.github.com/github-flavored-markdown/</a>.</p>
+
+<div class="codehilite">
+<pre><span></span><code><span class="k">def</span> <span class="nf">foo</span>
+    <span class="nb">puts</span> <span class="s2">&quot;hi&quot;</span>
+<span class="k">end</span>
+</code></pre>
+</div>

--- a/test/tm-cases/fenced_code_blocks_safe_highlight_old.opts
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight_old.opts
@@ -1,0 +1,1 @@
+{"extras": ["fenced-code-blocks"], "safe_mode": "escape"}

--- a/test/tm-cases/fenced_code_blocks_safe_highlight_old.tags
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight_old.tags
@@ -1,0 +1,1 @@
+extra fenced-code-blocks pygments pygments<2.14

--- a/test/tm-cases/fenced_code_blocks_safe_highlight_old.text
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight_old.text
@@ -1,0 +1,14 @@
+```python
+if True:
+    print "hi"
+```
+
+That's using the *fenced-code-blocks* extra with Python
+syntax coloring, if `pygments` is installed. See
+<http://github.github.com/github-flavored-markdown/>.
+
+```ruby
+def foo
+    puts "hi"
+end
+```

--- a/test/tm-cases/fenced_code_blocks_syntax_highlighting.html
+++ b/test/tm-cases/fenced_code_blocks_syntax_highlighting.html
@@ -9,8 +9,8 @@ syntax coloring, if <code>pygments</code> is installed. See
 <a href="http://github.github.com/github-flavored-markdown/">http://github.github.com/github-flavored-markdown/</a>.</p>
 
 <div class="codehilite">
-<pre><span></span><code><span class="k">def</span> <span class="nf">foo</span>
-    <span class="nb">puts</span> <span class="s2">&quot;hi&quot;</span>
+<pre><span></span><code><span class="k">def</span><span class="w"> </span><span class="nf">foo</span>
+<span class="w">    </span><span class="nb">puts</span><span class="w"> </span><span class="s2">&quot;hi&quot;</span>
 <span class="k">end</span>
 </code></pre>
 </div>

--- a/test/tm-cases/fenced_code_blocks_syntax_highlighting.tags
+++ b/test/tm-cases/fenced_code_blocks_syntax_highlighting.tags
@@ -1,1 +1,1 @@
-extra fenced-code-blocks pygments
+extra fenced-code-blocks pygments pygments>=2.14

--- a/test/tm-cases/fenced_code_blocks_syntax_highlighting_old.html
+++ b/test/tm-cases/fenced_code_blocks_syntax_highlighting_old.html
@@ -1,0 +1,16 @@
+<div class="codehilite">
+<pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+    <span class="nb">print</span> <span class="s2">&quot;hi&quot;</span>
+</code></pre>
+</div>
+
+<p>That's using the <em>fenced-code-blocks</em> extra with Python
+syntax coloring, if <code>pygments</code> is installed. See
+<a href="http://github.github.com/github-flavored-markdown/">http://github.github.com/github-flavored-markdown/</a>.</p>
+
+<div class="codehilite">
+<pre><span></span><code><span class="k">def</span> <span class="nf">foo</span>
+    <span class="nb">puts</span> <span class="s2">&quot;hi&quot;</span>
+<span class="k">end</span>
+</code></pre>
+</div>

--- a/test/tm-cases/fenced_code_blocks_syntax_highlighting_old.opts
+++ b/test/tm-cases/fenced_code_blocks_syntax_highlighting_old.opts
@@ -1,0 +1,1 @@
+{"extras": ["fenced-code-blocks"]}

--- a/test/tm-cases/fenced_code_blocks_syntax_highlighting_old.tags
+++ b/test/tm-cases/fenced_code_blocks_syntax_highlighting_old.tags
@@ -1,0 +1,1 @@
+extra fenced-code-blocks pygments pygments<2.14

--- a/test/tm-cases/fenced_code_blocks_syntax_highlighting_old.text
+++ b/test/tm-cases/fenced_code_blocks_syntax_highlighting_old.text
@@ -1,0 +1,14 @@
+```python
+if True:
+    print "hi"
+```
+
+That's using the *fenced-code-blocks* extra with Python
+syntax coloring, if `pygments` is installed. See
+<http://github.github.com/github-flavored-markdown/>.
+
+```ruby
+def foo
+    puts "hi"
+end
+```


### PR DESCRIPTION
As mentioned in #496, pygments 2.14 broke some of the tests around syntax highlighting.
This PR updates the test cases to include tests for Pygments<2.14 and Pygments>=2.14, which will be ran depending on what version of pygments you have installed