### PR TITLE
Fix images not being procesed correctly (#498)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## python-markdown2 2.4.8 (not yet released)
 
-(nothing yet)
+- [pull #499] Fix images not being procesed correctly (#498)
 
 
 ## python-markdown2 2.4.7

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1591,6 +1591,7 @@ class Markdown(object):
                         if "smarty-pants" in self.extras:
                             result = result.replace('"', self._escape_table['"'])
                         curr_pos = start_idx + len(result)
+                        anchor_allowed_pos = start_idx + len(result)
                         text = text[:start_idx] + result + text[url_end_idx:]
                     elif start_idx >= anchor_allowed_pos:
                         safe_link = self._safe_protocols.match(url) or url.startswith('#')

--- a/test/tm-cases/consecutive_image_links_issue498.html
+++ b/test/tm-cases/consecutive_image_links_issue498.html
@@ -1,0 +1,4 @@
+<p><a href="https://github.com/aoaostar"><img src="https://img.shields.io/badge/license-AGPL--3.0-orange?style=flat-square&color=0f6adb&logo=github" alt="A" /></a>
+<a href="https://github.com/aoaostar"><img src="https://img.shields.io/badge/license-AGPL--3.0-orange?style=flat-square&color=0f6adb&logo=github" alt="A" /></a>
+<a href="https://github.com/aoaostar"><img src="https://img.shields.io/badge/license-AGPL--3.0-orange?style=flat-square&color=0f6adb&logo=github" alt="A" /></a>
+<a href="https://github.com/aoaostar"><img src="https://img.shields.io/badge/license-AGPL--3.0-orange?style=flat-square&color=0f6adb&logo=github" alt="A" /></a></p>

--- a/test/tm-cases/consecutive_image_links_issue498.text
+++ b/test/tm-cases/consecutive_image_links_issue498.text
@@ -1,0 +1,4 @@
+[![A](https://img.shields.io/badge/license-AGPL--3.0-orange?style=flat-square&color=0f6adb&logo=github)](https://github.com/aoaostar)
+[![A](https://img.shields.io/badge/license-AGPL--3.0-orange?style=flat-square&color=0f6adb&logo=github)](https://github.com/aoaostar)
+[![A](https://img.shields.io/badge/license-AGPL--3.0-orange?style=flat-square&color=0f6adb&logo=github)](https://github.com/aoaostar)
+[![A](https://img.shields.io/badge/license-AGPL--3.0-orange?style=flat-square&color=0f6adb&logo=github)](https://github.com/aoaostar)


### PR DESCRIPTION
The issue was with the image processing in `_do_links`.

`anchor_allowed_pos` was not being set when images were processed. This was fine before #487 because when a markdown link was processed, the resulting text was usually longer, allowing `anchor_allowed_pos` to fall behind where the next link started.

After #487, URLs started to be hashed, which meant that the processed link could be shorter than the original text, meaning `anchor_allowed_pos` would overlap the start of the next link.

This PR fixes that by making sure `anchor_allowed_pos` is set correctly when processing links