### PR TITLE
Add <thead> tag to html-classes extra

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -56,7 +56,7 @@ see <https://github.com/trentm/python-markdown2/wiki/Extras> for details):
   highlighting when using fenced-code-blocks and highlightjs.
 * html-classes: Takes a dict mapping html tag names (lowercase) to a
   string to use for a "class" tag attribute. Currently only supports "img",
-  "table", "pre", "code", "ul" and "ol" tags. Add an issue if you require
+  "table", "thead", "pre", "code", "ul" and "ol" tags. Add an issue if you require
   this for other tags.
 * link-patterns: Auto-link given regex patterns in text (e.g. bug number
   references, revision number references).
@@ -1139,7 +1139,7 @@ class Markdown(object):
                 align_from_col_idx[col_idx] = ' style="text-align:right;"'
 
         # thead
-        hlines = ['<table%s>' % self._html_class_str_from_tag('table'), '<thead>', '<tr>']
+        hlines = ['<table%s>' % self._html_class_str_from_tag('table'), '<thead%s>' % self._html_class_str_from_tag('thead'), '<tr>']
         cols = [re.sub(escape_bar_re, '|', cell.strip()) for cell in re.split(split_bar_re, re.sub(trim_bar_re, "", re.sub(trim_space_re, "", head)))]
         for col_idx, col in enumerate(cols):
             hlines.append('  <th%s>%s</th>' % (

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1215,7 +1215,7 @@ class Markdown(object):
         add_hline('<table%s>' % self._html_class_str_from_tag('table'))
         # Check if first cell of first row is a header cell. If so, assume the whole row is a header row.
         if rows and rows[0] and re.match(r"^\s*~", rows[0][0]):
-            add_hline('<thead>', 1)
+            add_hline('<thead%s>' % self._html_class_str_from_tag('thead'), 1)
             add_hline('<tr>', 2)
             for cell in rows[0]:
                 add_hline("<th>{}</th>".format(format_cell(cell)), 3)

--- a/test/tm-cases/html_classes.html
+++ b/test/tm-cases/html_classes.html
@@ -1,5 +1,5 @@
 <table class="table table-striped">
-<thead>
+<thead class="table-light">
 <tr>
   <th>Header 1</th>
   <th><em>Header</em> 2</th>
@@ -18,7 +18,7 @@
 </table>
 
 <table class="table table-striped">
-    <thead>
+    <thead class="table-light">
         <tr>
             <th>Year</th>
             <th>Temperature (low)</th>

--- a/test/tm-cases/html_classes.opts
+++ b/test/tm-cases/html_classes.opts
@@ -7,6 +7,7 @@
       "code": "codesyntaxcolor",
       "img": "custom-image-class",
       "table": "table table-striped",
+      "thead": "table-light",
       "p": "col-xs-3 custom-paragraph-class",
       "ul": "custom-unordered-list-class",
       "ol": "custom-ordered-list-class"


### PR DESCRIPTION
PR to add `<thead>` tag to `html-classes` extra to support html classes for the header row of the table.