### PR TITLE
Fix link patterns extra matching against internal hashes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## python-markdown2 2.4.9 (not yet released)
 
 - [pull #500] Add `<thead>` tag to html-classes extra
+- [pull #501] Fix link patterns extra matching against internal hashes
 
 
 ## python-markdown2 2.4.8

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2642,6 +2642,9 @@ class Markdown(object):
 
     @staticmethod
     def _match_overlaps_substr(text, match, substr):
+        '''
+        Checks if a regex match overlaps with a substring in the given text.
+        '''
         for instance in re.finditer(re.escape(substr), text):
             start, end = instance.span()
             if start <= match.start() <= end:

--- a/test/tm-cases/link_patterns_hash_matching_issue287.html
+++ b/test/tm-cases/link_patterns_hash_matching_issue287.html
@@ -1,0 +1,1 @@
+<p>this is a test issue <a href="https://github.com/pyfa-org/Pyfa/issues/1234">#1234</a> with a test commit (<a href="https://github.com/pyfa-org/Pyfa/commit/addeddd">addeddd</a>) made by test <a href="https://github.com/username">@username</a> more text</p>

--- a/test/tm-cases/link_patterns_hash_matching_issue287.opts
+++ b/test/tm-cases/link_patterns_hash_matching_issue287.opts
@@ -1,0 +1,7 @@
+{"extras": ["link-patterns"],
+ "link_patterns": [
+    (re.compile("#(\d+)", re.I), r"https://github.com/pyfa-org/Pyfa/issues/\1"),
+    (re.compile("@(\w+)", re.I), r"https://github.com/\1"),
+    (re.compile("([0-9a-f]{6,40})", re.I), r"https://github.com/pyfa-org/Pyfa/commit/\1")
+    ]
+}

--- a/test/tm-cases/link_patterns_hash_matching_issue287.text
+++ b/test/tm-cases/link_patterns_hash_matching_issue287.text
@@ -1,0 +1,1 @@
+this is a test issue #1234 with a test commit (addeddd) made by test @username more text


### PR DESCRIPTION
This PR fixes #287 by preventing any link pattern regular expressions from matching against internal hashes.

It does this by checking the overlap between any link pattern match and the positions of the hashes in the text.
If a link pattern matches against text inside the start-end positions of an internal hash, it is ignored.