### PR TITLE
Fix HTML elements not unhashing correctly (issue 508)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - [pull #501] Fix link patterns extra matching against internal hashes
 - [pull #502] Replace deprecated `optparse` with `argparse`
 - [pull #506] Fix `_uniform_outdent` failing with empty strings (issue #505)
+- [pull #509] Fix HTML elements not unhashing correctly (issue 508)
 
 
 ## python-markdown2 2.4.8

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -890,7 +890,7 @@ class Markdown(object):
                     tag_count -= 1
                 else:
                     # if close tag is in same line
-                    if '</%s>' % is_markup.group(2) in chunk[is_markup.end():]:
+                    if self._tag_is_closed(is_markup.group(2), chunk):
                         # we must ignore these
                         is_markup = None
                     else:
@@ -907,6 +907,10 @@ class Markdown(object):
         result += block
 
         return result
+
+    def _tag_is_closed(self, tag_name, text):
+        # super basic check if number of open tags == number of closing tags
+        return len(re.findall('<%s(?:.*?)>' % tag_name, text)) == len(re.findall('</%s>' % tag_name, text))
 
     def _strip_link_definitions(self, text):
         # Strips link definitions from text, stores the URLs and titles in

--- a/test/tm-cases/hash_html_blocks_issue_508.html
+++ b/test/tm-cases/hash_html_blocks_issue_508.html
@@ -1,0 +1,8 @@
+<div><div></div>
+</div>
+
+<div></div>
+
+<div></div>
+
+<div></div>

--- a/test/tm-cases/hash_html_blocks_issue_508.html
+++ b/test/tm-cases/hash_html_blocks_issue_508.html
@@ -6,3 +6,7 @@
 <div></div>
 
 <div></div>
+
+<ul>
+<li>A</li>
+</ul>

--- a/test/tm-cases/hash_html_blocks_issue_508.text
+++ b/test/tm-cases/hash_html_blocks_issue_508.text
@@ -3,3 +3,5 @@
 <div></div>
 <div></div>
 <div></div>
+
+- A

--- a/test/tm-cases/hash_html_blocks_issue_508.text
+++ b/test/tm-cases/hash_html_blocks_issue_508.text
@@ -1,0 +1,5 @@
+<div><div></div>
+</div>
+<div></div>
+<div></div>
+<div></div>


### PR DESCRIPTION
This PR fixes #508 by patching the close tag detection in the strict block tag hashing function.

The issue was with lines such as:
```html
<div><div></div>
</div>
```
Where the first opening `<div>` tag would be deemed as "closed" because there was a closing `</div>` tag present on the same line.

The fix is to count the number of opening and closing tags on a single line. If they are inequal, the tag is deemed "open".