### PR TITLE
Allow link patterns to be passed via extras dict

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - [pull #506] Fix `_uniform_outdent` failing with empty strings (issue #505)
 - [pull #509] Fix HTML elements not unhashing correctly (issue 508)
 - [pull #511] Remove deprecated `imp` module (issue #510)
+- [pull #512] Allow link patterns to be passed via extras dict
 
 
 ## python-markdown2 2.4.8

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -235,11 +235,14 @@ class Markdown(object):
         self._instance_extras = self.extras.copy()
 
         if 'link-patterns' in self.extras:
+            # allow link patterns via extras dict without kwarg explicitly set
+            link_patterns = link_patterns or extras['link-patterns']
             if link_patterns is None:
                 # if you have specified that the link-patterns extra SHOULD
                 # be used (via self.extras) but you haven't provided anything
                 # via the link_patterns argument then an error is raised
                 raise MarkdownError("If the 'link-patterns' extra is used, an argument for 'link_patterns' is required")
+
         self.link_patterns = link_patterns
         self.footnote_title = footnote_title
         self.footnote_return_symbol = footnote_return_symbol


### PR DESCRIPTION
This PR allows the user to pass in link patterns via the `extras` argument.
Previously, the user would have to remember to set two arguments correctly:
```python
# correct
markdown(text, extras=['link-patterns'], link_patterns=[...])
# incorrect
markdown(text, link_patterns=[...])  # doesn't raise but doesn't activate extra
markdown(text, extras=['link-patterns'])  # raises error
markdown(text, extras={'link-patterns': [...]})  # raises error
```
This PR enables that last use case