### PR TITLE
Fix relative links not working in safe mode (issue #254)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - [pull #509] Fix HTML elements not unhashing correctly (issue 508)
 - [pull #511] Remove deprecated `imp` module (issue #510)
 - [pull #512] Allow link patterns to be passed via extras dict
+- [pull #513] Fix relative links not working in safe mode (issue #254)
 
 
 ## python-markdown2 2.4.8

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1484,40 +1484,10 @@ class Markdown(object):
         return key
 
     # _safe_href is copied from pagedown's Markdown.Sanitizer.js
-    # Inlining the entire license as I don't have the time to add it properly for upstreaming
     # From: https://github.com/StackExchange/pagedown/blob/master/LICENSE.txt
-    #
-    # A javascript port of Markdown, as used on Stack Overflow
-    # and the rest of Stack Exchange network.
-    #
-    # Largely based on showdown.js by John Fraser (Attacklab).
-    #
-    # Original Markdown Copyright (c) 2004-2005 John Gruber
-    #   <http://daringfireball.net/projects/markdown/>
-    #
-    #
     # Original Showdown code copyright (c) 2007 John Fraser
-    #
     # Modifications and bugfixes (c) 2009 Dana Robinson
     # Modifications and bugfixes (c) 2009-2014 Stack Exchange Inc.
-    #
-    # Permission is hereby granted, free of charge, to any person obtaining a copy
-    # of this software and associated documentation files (the "Software"), to deal
-    # in the Software without restriction, including without limitation the rights
-    # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    # copies of the Software, and to permit persons to whom the Software is
-    # furnished to do so, subject to the following conditions:
-    #
-    # The above copyright notice and this permission notice shall be included in
-    # all copies or substantial portions of the Software.
-    #
-    # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    # THE SOFTWARE.
     _safe_href = re.compile(r'^((https?|ftp):\/\/|\/|\.|#)[-A-Za-z0-9+&@#\/%?=~_|!:,.;\(\)*[\]$]+$', re.I)
 
     def _do_links(self, text):

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1483,7 +1483,43 @@ class Markdown(object):
         self._escape_table[url] = key
         return key
 
-    _safe_protocols = re.compile(r'(https?|ftp):', re.I)
+    # _safe_href is copied from pagedown's Markdown.Sanitizer.js
+    # Inlining the entire license as I don't have the time to add it properly for upstreaming
+    # From: https://github.com/StackExchange/pagedown/blob/master/LICENSE.txt
+    #
+    # A javascript port of Markdown, as used on Stack Overflow
+    # and the rest of Stack Exchange network.
+    #
+    # Largely based on showdown.js by John Fraser (Attacklab).
+    #
+    # Original Markdown Copyright (c) 2004-2005 John Gruber
+    #   <http://daringfireball.net/projects/markdown/>
+    #
+    #
+    # Original Showdown code copyright (c) 2007 John Fraser
+    #
+    # Modifications and bugfixes (c) 2009 Dana Robinson
+    # Modifications and bugfixes (c) 2009-2014 Stack Exchange Inc.
+    #
+    # Permission is hereby granted, free of charge, to any person obtaining a copy
+    # of this software and associated documentation files (the "Software"), to deal
+    # in the Software without restriction, including without limitation the rights
+    # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    # copies of the Software, and to permit persons to whom the Software is
+    # furnished to do so, subject to the following conditions:
+    #
+    # The above copyright notice and this permission notice shall be included in
+    # all copies or substantial portions of the Software.
+    #
+    # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    # THE SOFTWARE.
+    _safe_href = re.compile(r'^((https?|ftp):\/\/|\/|\.|#)[-A-Za-z0-9+&@#\/%?=~_|!:,.;\(\)*[\]$]+$', re.I)
+
     def _do_links(self, text):
         """Turn Markdown link shortcuts into XHTML <a> and <img> tags.
 
@@ -1601,7 +1637,7 @@ class Markdown(object):
                         anchor_allowed_pos = start_idx + len(result)
                         text = text[:start_idx] + result + text[url_end_idx:]
                     elif start_idx >= anchor_allowed_pos:
-                        safe_link = self._safe_protocols.match(url) or url.startswith('#')
+                        safe_link = self._safe_href.match(url)
                         if self.safe_mode and not safe_link:
                             result_head = '<a href="#"%s>' % (title_str)
                         else:
@@ -1657,7 +1693,7 @@ class Markdown(object):
                             curr_pos = start_idx + len(result)
                             text = text[:start_idx] + result + text[match.end():]
                         elif start_idx >= anchor_allowed_pos:
-                            if self.safe_mode and not self._safe_protocols.match(url):
+                            if self.safe_mode and not self._safe_href.match(url):
                                 result_head = '<a href="#"%s>' % (title_str)
                             else:
                                 result_head = '<a href="%s"%s>' % (self._protect_url(url), title_str)

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1488,7 +1488,7 @@ class Markdown(object):
     # Original Showdown code copyright (c) 2007 John Fraser
     # Modifications and bugfixes (c) 2009 Dana Robinson
     # Modifications and bugfixes (c) 2009-2014 Stack Exchange Inc.
-    _safe_href = re.compile(r'^((https?|ftp):\/\/|\/|\.|#)[-A-Za-z0-9+&@#\/%?=~_|!:,.;\(\)*[\]$]+$', re.I)
+    _safe_href = re.compile(r'^((https?|ftp):\/\/|\/|\.|#)[-A-Za-z0-9+&@#\/%?=~_|!:,.;\(\)*[\]$]*$', re.I)
 
     def _do_links(self, text):
         """Turn Markdown link shortcuts into XHTML <a> and <img> tags.

--- a/test/tm-cases/basic_safe_mode.html
+++ b/test/tm-cases/basic_safe_mode.html
@@ -6,13 +6,13 @@
 
 <p>[HTML_REMOVED]alert(1)[HTML_REMOVED]</p>
 
-<p><a href="http://example.com&quot;onclick=&quot;alert(1)">link1</a></p>
+<p><a href="#">link1</a></p>
 
 <p><a href="http://example.com" title="title&quot;onclick=&quot;alert(1)">link2</a></p>
 
-<p><a href="http://example.com&gt;[HTML_REMOVED]alert(1)[HTML_REMOVED]">link3</a></p>
+<p><a href="#">link3</a></p>
 
-<p><a href="http://example.com&gt;[HTML_REMOVED]alert(1)[HTML_REMOVED]">link4 &gt;[HTML_REMOVED]alert(1)[HTML_REMOVED]</a></p>
+<p><a href="#">link4 &gt;[HTML_REMOVED]alert(1)[HTML_REMOVED]</a></p>
 
 <p><a href="#">link5</a></p>
 

--- a/test/tm-cases/relative_links_safe_mode.html
+++ b/test/tm-cases/relative_links_safe_mode.html
@@ -1,0 +1,6 @@
+<p><a href="https://www.hostname.com/absolute/path">link1</a>
+<a href="https://www.hostname.com/absolute/path#anchor-on-another-page">link2</a>
+<a href="#anchor-on-this-page">link3</a>
+<a href="/">link4</a>
+<a href="/absolute/path">link5</a>
+<a href="../relative/path">link6</a></p>

--- a/test/tm-cases/relative_links_safe_mode.opts
+++ b/test/tm-cases/relative_links_safe_mode.opts
@@ -1,0 +1,1 @@
+{"safe_mode": "escape"}

--- a/test/tm-cases/relative_links_safe_mode.text
+++ b/test/tm-cases/relative_links_safe_mode.text
@@ -1,0 +1,6 @@
+[link1](https://www.hostname.com/absolute/path)
+[link2](https://www.hostname.com/absolute/path#anchor-on-another-page)
+[link3](#anchor-on-this-page)
+[link4](/)
+[link5](/absolute/path)
+[link6](../relative/path)


### PR DESCRIPTION
This PR fixes #254 by cherry-picking commit  pknowles@76c663d and adding a test case for this bug.

I removed the full MIT license text from the original commit, keeping the copyright attributions and a link to the license instead.
For such a small snippet of code, I think this approach is sufficient? In-lining is messy and I'm not sure where else the license would be stored.

Happy to hear feedback on this