### PR TITLE
Fix two list item related bugs

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2196,7 +2196,7 @@ class Markdown(object):
 
         return self._uniform_indent(
             '\n%s%s%s\n' % (open_tag, self._escape_table[waves], close_tag),
-            lead_indent, include_empty_lines=True
+            lead_indent, indent_empty_lines=True
         )
 
     def _do_wavedrom_blocks(self, text):
@@ -2607,13 +2607,16 @@ class Markdown(object):
         # Remove one level of line-leading tabs or spaces
         return self._outdent_re.sub('', text)
 
-    def _uniform_outdent(self, text, min_outdent=None, max_outdent=None):
-        # Removes the smallest common leading indentation from each (non empty)
-        # line of `text` and returns said indent along with the outdented text.
-        # The `min_outdent` kwarg makes sure the smallest common whitespace
-        # must be at least this size
-        # The `max_outdent` sets the maximum amount a line can be
-        # outdented by
+    @staticmethod
+    def _uniform_outdent(text, min_outdent=None, max_outdent=None):
+        '''
+        Removes the smallest common leading indentation from each (non empty)
+        line of `text` and returns said indent along with the outdented text.
+
+        Args:
+            min_outdent: make sure the smallest common whitespace is at least this size
+            max_outdent: the maximum amount a line can be outdented by
+        '''
 
         # find the leading whitespace for every line
         whitespace = [
@@ -2647,11 +2650,26 @@ class Markdown(object):
 
         return outdent, ''.join(outdented)
 
-    def _uniform_indent(self, text, indent, include_empty_lines=False):
-        return ''.join(
-            (indent + line if line.strip() or include_empty_lines else '')
-            for line in text.splitlines(True)
-        )
+    @staticmethod
+    def _uniform_indent(text, indent, include_empty_lines=False, indent_empty_lines=False):
+        '''
+        Uniformly indent a block of text by a fixed amount
+
+        Args:
+            text: the text to indent
+            indent: a string containing the indent to apply
+            include_empty_lines: don't remove whitespace only lines
+            indent_empty_lines: indent whitespace only lines with the rest of the text
+        '''
+        blocks = []
+        for line in text.splitlines(True):
+            if line.strip() or indent_empty_lines:
+                blocks.append(indent + line)
+            elif include_empty_lines:
+                blocks.append(line)
+            else:
+                blocks.append('')
+        return ''.join(blocks)
 
     @staticmethod
     def _match_overlaps_substr(text, match, substr):

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1887,7 +1887,8 @@ class Markdown(object):
         item = match.group(4)
         leading_line = match.group(1)
         if leading_line or "\n\n" in item or self._last_li_endswith_two_eols:
-            item = self._run_block_gamut(self._outdent(item))
+            item = self._uniform_outdent(item, min_outdent=' ', max_outdent=self.tab)[1]
+            item = self._run_block_gamut(item)
         else:
             # Recursion for sub-lists:
             item = self._do_lists(self._uniform_outdent(item, min_outdent=' ')[1])

--- a/test/tm-cases/markdown_in_html_in_lists.html
+++ b/test/tm-cases/markdown_in_html_in_lists.html
@@ -1,0 +1,37 @@
+<ul>
+<li><p>Item 1</p>
+
+<div>
+
+<h6>Block one</h6>
+
+<p>Some text</p>
+
+</div></li>
+<li><p>Item 2</p>
+
+<ul>
+<li><p>Item 3</p>
+
+<ul>
+<li><p>Item 4</p>
+
+<div>
+
+<h6>Block two</h6>
+
+<p>Some text</p>
+
+</div></li>
+</ul></li>
+<li><p>Item 5</p>
+
+<div>
+
+<h6>Block three</h6>
+
+<p>Some text</p>
+
+</div></li>
+</ul></li>
+</ul>

--- a/test/tm-cases/markdown_in_html_in_lists.opts
+++ b/test/tm-cases/markdown_in_html_in_lists.opts
@@ -1,0 +1,1 @@
+{"extras": ["markdown-in-html"]}

--- a/test/tm-cases/markdown_in_html_in_lists.text
+++ b/test/tm-cases/markdown_in_html_in_lists.text
@@ -1,0 +1,17 @@
+- Item 1
+  <div markdown="1">
+  ###### Block one
+  Some text
+  </div>
+- Item 2
+  - Item 3
+    - Item 4
+      <div markdown="1">
+      ###### Block two
+      Some text
+      </div>
+  - Item 5
+    <div markdown="1">
+    ###### Block three
+    Some text
+    </div>

--- a/test/tm-cases/nested_list.html
+++ b/test/tm-cases/nested_list.html
@@ -34,3 +34,18 @@
 </ul></li>
 <li>Item 3 - yes! just a single item</li>
 </ul>
+
+<p>Other more different nested list:</p>
+
+<ul>
+<li><p>Item 1
+With some space after</p></li>
+<li><p>Item 2</p>
+
+<ul>
+<li>Item 3
+<ul>
+<li>Item 4</li>
+</ul></li>
+</ul></li>
+</ul>

--- a/test/tm-cases/nested_list.text
+++ b/test/tm-cases/nested_list.text
@@ -21,3 +21,13 @@ Slightly more nested list:
     + The
     + Code
 * Item 3 - yes! just a single item
+
+
+Other more different nested list:
+
+- Item 1
+  With some space after
+
+- Item 2
+  - Item 3
+    - Item 4

--- a/test/tm-cases/seperated_list_items.html
+++ b/test/tm-cases/seperated_list_items.html
@@ -1,0 +1,12 @@
+<ul>
+<li><p>Item 1
+ABCDEF</p></li>
+<li><p>Item 2</p>
+
+<ul>
+<li>Item 3
+<ul>
+<li>Item 4</li>
+</ul></li>
+</ul></li>
+</ul>

--- a/test/tm-cases/seperated_list_items.text
+++ b/test/tm-cases/seperated_list_items.text
@@ -1,0 +1,6 @@
+- Item 1
+  ABCDEF
+
+- Item 2
+  - Item 3
+    - Item 4


### PR DESCRIPTION
### Bug 1: List items being incorrectly nested if preceded by `\n\n`

```markdown
- Item 1
  ABCDEF

- Item 2
  - Item 3
    - Item 4
```
While processing `Item 2`, `Item 4` would erroneously be flattened to the same level as `Item 3`.
In `_list_item_sub` if the last processed list item (in this case `Item 1`) ended with `\n\n`, the current list item would be passed to `self._outdent`, flattening the child list items.

This bug was fixed by instead passing the current list item to `self._uniform_outdent` and outdenting it by 1-4 spaces. 

### Bug 2: HTML blocks with `markdown="1"` not being processed correctly when inside list items

The `_list_item_sub` function assumes that most list items, if they don't contain `\n\n`, should be run through the span gamut.
This assumption causes the following markdown to be incorrectly converted:
```markdown
- Item 1
  <div markdown="1">
  ###### This line would not be converted
  Some text
  </div>
```

List items are allowed to contain `div` blocks, which can contain other block elements such as headers. However, since this example does not contain `\n\n`, it would be run through the span gamut and the header would not be processed.

The fix for this was to add a dedicated `_do_markdown_in_html` function that piggy-backs off of `_strict_tag_block_sub`.
It will find and hash indented HTML blocks, resulting in the following markdown:
```markdown
- Item 1

  md5-somehash

  ###### This line would not be converted
  Some text

  md5-somehash

```

Due to the presence of `\n\n`, the `_list_item_sub` will now process these correctly using the block gamut.

Alternatives considered:
- Running all list items through the block gamut
  - Results in `<li><p>some text</p></li>`
- Tweaking `_strict_tag_block_sub` to always hash indented HTML blocks
  - Could not get this working. Caused 40+ test failures


### Other notable changes
- Refactored `_uniform_indent` to give better control on what happens to whitespace-only lines
- Made `_uniform_(in|out)dent` staticmethods and added docstrings