### PR TITLE
Add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Report a parsing error, unexpected output and other bugs
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Attach a minimal markdown snippet that causes the bug to occur. This should be placed inside a fenced code block to escape GitHub's formatting.
+
+If your snippet contains fenced code blocks then you can escape them by adding more backticks to the enclosing block. See the [this GitHub article](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks) for an example.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Debug info**
+Version of library being used:
+
+Any extras being used:
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
This PR adds a bug report issue template to help produce better bug reports.

The template requests a few specific things from users that I have found to be helpful when fixing issues:
- Clear description of bug + expected behaviour
- A markdown snippet inside a fenced code blocks (to escape GitHub's formatting)
  - Included instructions on how to escape fenced code blocks inside the markdown snippet
- Version of library in use + any extras

Let me know if I've missed any useful info that should be included