### PR TITLE
Allow more relative links in safe mode (issue #517)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## python-markdown2 2.4.10 (not yet released)
 
-(nothing yet)
+- [pull #520] Allow more relative links in safe mode (issue #517)
 
 
 ## python-markdown2 2.4.9

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1507,7 +1507,7 @@ class Markdown(object):
         self._escape_table[url] = key
         return key
 
-    _safe_protocols = r'(?:https?|ftp):\/\/|(?:mailto|tel):|\/|\.{,2}|#'
+    _safe_protocols = r'(?:https?|ftp):\/\/|(?:mailto|tel):'
 
     @property
     def _safe_href(self):
@@ -1518,14 +1518,14 @@ class Markdown(object):
         Modifications and bugfixes (c) 2009 Dana Robinson
         Modifications and bugfixes (c) 2009-2014 Stack Exchange Inc.
         '''
-        safe = r'-\w/'
+        safe = r'-\w'
         # omitted ['"<>] for XSS reasons
-        less_safe = r'\.!#$%&\(\)\+,/:;=\?@\[\]^`\{\}\|~'
+        less_safe = r'#/\.!#$%&\(\)\+,/:;=\?@\[\]^`\{\}\|~'
         # dot seperated hostname, optional port number, not followed by protocol seperator
         domain = r'(?:[%s]+(?:\.[%s]+)*)(?::\d+/?)?(?![^:/]*:/*)' % (safe, safe)
         fragment = r'[%s]*' % (safe + less_safe)
 
-        return re.compile(r'^(%s)?(%s)(%s)$' % (self._safe_protocols, domain, fragment), re.I)
+        return re.compile(r'^(?:(%s)?(%s)(%s)|(#|\.{,2}/)(%s))$' % (self._safe_protocols, domain, fragment, fragment), re.I)
 
     def _do_links(self, text):
         """Turn Markdown link shortcuts into XHTML <a> and <img> tags.

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1509,9 +1509,8 @@ class Markdown(object):
 
     _safe_protocols = r'(?:https?|ftp):\/\/|(?:mailto|tel):|\/|\.{,2}|#'
 
-    @classmethod
     @property
-    def _safe_href(cls):
+    def _safe_href(self):
         '''
         _safe_href is adapted from pagedown's Markdown.Sanitizer.js
         From: https://github.com/StackExchange/pagedown/blob/master/LICENSE.txt
@@ -1526,7 +1525,7 @@ class Markdown(object):
         domain = r'(?:[%s]+(?:\.[%s]+)*)(?::\d+/?)?(?![^:/]*:/*)' % (safe, safe)
         fragment = r'[%s]*' % (safe + less_safe)
 
-        return re.compile(r'^(%s)?(%s)(%s)$' % (cls._safe_protocols, domain, fragment), re.I)
+        return re.compile(r'^(%s)?(%s)(%s)$' % (self._safe_protocols, domain, fragment), re.I)
 
     def _do_links(self, text):
         """Turn Markdown link shortcuts into XHTML <a> and <img> tags.

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1509,8 +1509,9 @@ class Markdown(object):
 
     _safe_protocols = r'(?:https?|ftp):\/\/|(?:mailto|tel):|\/|\.{,2}|#'
 
+    @classmethod
     @property
-    def _safe_href(self):
+    def _safe_href(cls):
         '''
         _safe_href is adapted from pagedown's Markdown.Sanitizer.js
         From: https://github.com/StackExchange/pagedown/blob/master/LICENSE.txt
@@ -1525,7 +1526,7 @@ class Markdown(object):
         domain = r'(?:[%s]+(?:\.[%s]+)*)(?::\d+/?)?(?![^:/]*:/*)' % (safe, safe)
         fragment = r'[%s]*' % (safe + less_safe)
 
-        return re.compile(r'^(%s)?(%s)(%s)$' % (self._safe_protocols, domain, fragment), re.I)
+        return re.compile(r'^(%s)?(%s)(%s)$' % (cls._safe_protocols, domain, fragment), re.I)
 
     def _do_links(self, text):
         """Turn Markdown link shortcuts into XHTML <a> and <img> tags.

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1522,7 +1522,7 @@ class Markdown(object):
         # omitted ['"<>] for XSS reasons
         less_safe = r'#/\.!#$%&\(\)\+,/:;=\?@\[\]^`\{\}\|~'
         # dot seperated hostname, optional port number, not followed by protocol seperator
-        domain = r'(?:[%s]+(?:\.[%s]+)*)(?::\d+/?)?(?![^:/]*:/*)' % (safe, safe)
+        domain = r'(?:[%s]+(?:\.[%s]+)*)(?:(?<!tel):\d+/?)?(?![^:/]*:/*)' % (safe, safe)
         fragment = r'[%s]*' % (safe + less_safe)
 
         return re.compile(r'^(?:(%s)?(%s)(%s)|(#|\.{,2}/)(%s))$' % (self._safe_protocols, domain, fragment, fragment), re.I)

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1507,12 +1507,25 @@ class Markdown(object):
         self._escape_table[url] = key
         return key
 
-    # _safe_href is copied from pagedown's Markdown.Sanitizer.js
-    # From: https://github.com/StackExchange/pagedown/blob/master/LICENSE.txt
-    # Original Showdown code copyright (c) 2007 John Fraser
-    # Modifications and bugfixes (c) 2009 Dana Robinson
-    # Modifications and bugfixes (c) 2009-2014 Stack Exchange Inc.
-    _safe_href = re.compile(r'^((https?|ftp):\/\/|\/|\.|#)[-A-Za-z0-9+&@#\/%?=~_|!:,.;\(\)*[\]$]*$', re.I)
+    _safe_protocols = r'(?:https?|ftp):\/\/|(?:mailto|tel):|\/|\.{,2}|#'
+
+    @property
+    def _safe_href(self):
+        '''
+        _safe_href is adapted from pagedown's Markdown.Sanitizer.js
+        From: https://github.com/StackExchange/pagedown/blob/master/LICENSE.txt
+        Original Showdown code copyright (c) 2007 John Fraser
+        Modifications and bugfixes (c) 2009 Dana Robinson
+        Modifications and bugfixes (c) 2009-2014 Stack Exchange Inc.
+        '''
+        safe = r'-\w/'
+        # omitted ['"<>] for XSS reasons
+        less_safe = r'\.!#$%&\(\)\+,/:;=\?@\[\]^`\{\}\|~'
+        # dot seperated hostname, optional port number, not followed by protocol seperator
+        domain = r'(?:[%s]+(?:\.[%s]+)*)(?::\d+/?)?(?![^:/]*:/*)' % (safe, safe)
+        fragment = r'[%s]*' % (safe + less_safe)
+
+        return re.compile(r'^(%s)?(%s)(%s)$' % (self._safe_protocols, domain, fragment), re.I)
 
     def _do_links(self, text):
         """Turn Markdown link shortcuts into XHTML <a> and <img> tags.

--- a/test/tm-cases/link_safe_urls.html
+++ b/test/tm-cases/link_safe_urls.html
@@ -1,11 +1,47 @@
+<h1>Normal links</h1>
+
 <p><a href="https://www.example.com">Safe link 1</a></p>
 
 <p><a href="http://www.example.com">Safe link 2</a></p>
 
 <p><a href="ftp://www.example.com">Safe link 3</a></p>
 
-<p><a href="#anchor">Safe link 4</a></p>
+<p><a href="mailto:emailaddress@server.com">Safe link 4</a></p>
+
+<p><a href="tel:0123456789">Safe link 5</a></p>
+
+<p><a href="#anchor">Safe link 6</a></p>
+
+<h1>Bad protocols</h1>
 
 <p><a href="#">Unsafe link 1</a></p>
 
 <p><a href="#">Unsafe link 2</a></p>
+
+<h1>Relative links</h1>
+
+<p><a href="example">Safe link 1</a></p>
+
+<p><a href="./example">Safe link 2</a></p>
+
+<p><a href="../../example">Safe link 3</a></p>
+
+<p><a href="/example">Safe link 4</a></p>
+
+<p><a href="#">Unsafe link 1</a></p>
+
+<h1>Edge cases</h1>
+
+<p><a href="www.example.com/abc:def">Safe link 1</a></p>
+
+<p><a href="www.example.com/abc:/def">Safe link 2</a></p>
+
+<p><a href="https://www.example.com:4200">Safe link 3</a></p>
+
+<p><a href="https://www.example.com:4200/abcdef">Safe link 4</a></p>
+
+<p><a href="#">Unsafe link 1</a></p>
+
+<p><a href="#">Unsafe link 2</a></p>
+
+<p><a href="#">Unsafe link 3</a></p>

--- a/test/tm-cases/link_safe_urls.text
+++ b/test/tm-cases/link_safe_urls.text
@@ -1,11 +1,47 @@
+# Normal links
+
 [Safe link 1](https://www.example.com)
 
 [Safe link 2](http://www.example.com)
 
 [Safe link 3](ftp://www.example.com)
 
-[Safe link 4](#anchor)
+[Safe link 4](mailto:emailaddress@server.com)
+
+[Safe link 5](tel:0123456789)
+
+[Safe link 6](#anchor)
+
+# Bad protocols
 
 [Unsafe link 1](unknown://www.example.com)
 
-[Unsafe link 2](example)
+[Unsafe link 2](mailfrom:www.example.com)
+
+# Relative links
+
+[Safe link 1](example)
+
+[Safe link 2](./example)
+
+[Safe link 3](../../example)
+
+[Safe link 4](/example)
+
+[Unsafe link 1](.../www.example.com)
+
+# Edge cases
+
+[Safe link 1](www.example.com/abc:def)
+
+[Safe link 2](www.example.com/abc:/def)
+
+[Safe link 3](https://www.example.com:4200)
+
+[Safe link 4](https://www.example.com:4200/abcdef)
+
+[Unsafe link 1](unknown://www.example.com://abc)
+
+[Unsafe link 2](C:/Windows/System32)
+
+[Unsafe link 3](C:\Windows\System32)


### PR DESCRIPTION
This PR fixes #517 by expanding the scope of the `_safe_href` regex to include more types of relative links.

Previously, #513 was merged which allowed the following kinds of relative links:
```
[issue1](./issue1)
[issue1](/issue1)
```
But did not allow this: `[link](issue1)`

The new regex should allow URLs to omit the protocol section of the URL or use relative paths instead of a protocol (eg: `./`, `../`, `/`) followed by a hostname, optional port number and then the rest of the URL.

I've also expanded the number of accepted protocols to include `mailto:` and `tel:`.

Also, the `_safe_protocols` attribute has been re-introduced to allow users to extend the number of allowed protocols when operating in safe mode (see [this comment](https://github.com/trentm/python-markdown2/issues/517#issuecomment-1606284092)).