### PR TITLE
Always restore hashed HTML blocks (issue #185)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## python-markdown2 2.4.10 (not yet released)
 
 - [pull #520] Allow more relative links in safe mode (issue #517)
+- [pull #521] Always restore hashed HTML blocks (issue #185)
 
 
 ## python-markdown2 2.4.9

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2638,9 +2638,12 @@ class Markdown(object):
 
     def _unescape_special_chars(self, text):
         # Swap back in all the special characters we've hidden.
+        hashmap = tuple(self._escape_table.items()) + tuple(self._code_table.items())
+        # html_blocks table is in format {hash: item} compared to usual {item: hash}
+        hashmap += tuple(tuple(reversed(i)) for i in self.html_blocks.items())
         while True:
             orig_text = text
-            for ch, hash in list(self._escape_table.items()) + list(self._code_table.items()):
+            for ch, hash in hashmap:
                 text = text.replace(hash, ch)
             if text == orig_text:
                 break

--- a/test/tm-cases/hash_html_blocks.html
+++ b/test/tm-cases/hash_html_blocks.html
@@ -1,0 +1,9 @@
+<div
+>
+<h3>Archons of the Colophon</h3>
+
+
+<p>by Paco Xander Nathan
+</p>
+
+</div>

--- a/test/tm-cases/hash_html_blocks.text
+++ b/test/tm-cases/hash_html_blocks.text
@@ -1,0 +1,6 @@
+<div
+>
+<h3>Archons of the Colophon</h3>
+<p>by Paco Xander Nathan
+</p>
+</div>


### PR DESCRIPTION
This PR fixes #185 by always restoring hashed html blocks at the end of conversion.

The original markdown snippet was as follows:
```html
<div
>
<h3>Archons of the Colophon</h3>
<p>by Paco Xander Nathan
</p>
</div>
```

The `<p>` tag would be hashed by the strict block sub but the enclosing `<div\n>` would only be caught by the liberal block sub, leading to nested hashes.

Nested hashes don't get fully unravelled in `_form_paragraphs`, only 1 layer does, so hashes would remain in the text until the end of the conversion process.
Since `_unescape_special_chars` doesn't process HTML blocks (only special chars and code blocks), the hash would remain in the final output.

What I've done is make sure that `_unescape_special_chars` also processes HTML blocks when performing its un-hashing.