### PR TITLE
Add `middle-word-em` extra

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## python-markdown2 2.4.10 (not yet released)
 
 - [pull #520] Allow more relative links in safe mode (issue #517)
+- [pull #522] Add `middle-word-em` extra
 
 
 ## python-markdown2 2.4.9

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2307,8 +2307,8 @@ class Markdown(object):
     _code_friendly_em_re = r"\*(?=\S)(.+?)(?<=\S)\*"
     def _do_italics_and_bold(self, text):
         if self.extras.get('middle-word-em', True) is False:
-            code_friendly_em_re = r'(?<=\s)%s(?=\s)' % self._code_friendly_em_re
-            em_re = r'(?<=\s)%s(?=\s)' % self._em_re
+            code_friendly_em_re = r'(?<=\b)%s(?=\b)' % self._code_friendly_em_re
+            em_re = r'(?<=\b)%s(?=\b)' % self._em_re
         else:
             code_friendly_em_re = self._code_friendly_em_re
             em_re = self._em_re

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -66,6 +66,9 @@ see <https://github.com/trentm/python-markdown2/wiki/Extras> for details):
   some limitations.
 * metadata: Extract metadata from a leading '---'-fenced block.
   See <https://github.com/trentm/python-markdown2/issues/77> for details.
+* middle-word-em: Allows or disallows emphasis syntax in the middle of words,
+  defaulting to allow. Disabling this means that `this_text_here` will not be
+  converted to `this<em>text</em>here`.
 * nofollow: Add `rel="nofollow"` to add `<a>` tags with an href. See
   <http://en.wikipedia.org/wiki/Nofollow>.
 * numbering: Support of generic counters.  Non standard extension to
@@ -2299,17 +2302,24 @@ class Markdown(object):
         return text
 
     _strong_re = re.compile(r"(\*\*|__)(?=\S)(.+?[*_]*)(?<=\S)\1", re.S)
-    _em_re = re.compile(r"(\*|_)(?=\S)(.+?)(?<=\S)\1", re.S)
+    _em_re = r"(\*|_)(?=\S)(.+?)(?<=\S)\1"
     _code_friendly_strong_re = re.compile(r"\*\*(?=\S)(.+?[*_]*)(?<=\S)\*\*", re.S)
-    _code_friendly_em_re = re.compile(r"\*(?=\S)(.+?)(?<=\S)\*", re.S)
+    _code_friendly_em_re = r"\*(?=\S)(.+?)(?<=\S)\*"
     def _do_italics_and_bold(self, text):
+        if self.extras.get('middle-word-em', True) is False:
+            code_friendly_em_re = r'(?<=\s)%s(?=\s)' % self._code_friendly_em_re
+            em_re = r'(?<=\s)%s(?=\s)' % self._em_re
+        else:
+            code_friendly_em_re = self._code_friendly_em_re
+            em_re = self._em_re
+
         # <strong> must go first:
         if "code-friendly" in self.extras:
             text = self._code_friendly_strong_re.sub(r"<strong>\1</strong>", text)
-            text = self._code_friendly_em_re.sub(r"<em>\1</em>", text)
+            text = re.sub(code_friendly_em_re, r"<em>\1</em>", text, flags=re.S)
         else:
             text = self._strong_re.sub(r"<strong>\2</strong>", text)
-            text = self._em_re.sub(r"<em>\2</em>", text)
+            text = re.sub(em_re, r"<em>\2</em>", text, flags=re.S)
         return text
 
     # "smarty-pants" extra: Very liberal in interpreting a single prime as an

--- a/test/tm-cases/middle_word_em.html
+++ b/test/tm-cases/middle_word_em.html
@@ -1,0 +1,2 @@
+<p>When middle word emphasis is disabled strings like 'self.this_long_attr' should not
+become <code>self.this&lt;em&gt;long&lt;/em&gt;attr</code>.</p>

--- a/test/tm-cases/middle_word_em.html
+++ b/test/tm-cases/middle_word_em.html
@@ -1,2 +1,5 @@
 <p>When middle word emphasis is disabled strings like 'self.this_long_attr' should not
 become <code>self.this&lt;em&gt;long&lt;/em&gt;attr</code>.</p>
+
+<p>Emphasis will <em>only</em> occur when the word is surrounded with whitespace.
+This should still work with <em>my_filename</em>.</p>

--- a/test/tm-cases/middle_word_em.opts
+++ b/test/tm-cases/middle_word_em.opts
@@ -1,0 +1,1 @@
+{'extras': {'middle-word-em': False}}

--- a/test/tm-cases/middle_word_em.text
+++ b/test/tm-cases/middle_word_em.text
@@ -1,2 +1,5 @@
 When middle word emphasis is disabled strings like 'self.this_long_attr' should not
 become `self.this<em>long</em>attr`.
+
+Emphasis will _only_ occur when the word is surrounded with whitespace.
+This should still work with _my_filename_.

--- a/test/tm-cases/middle_word_em.text
+++ b/test/tm-cases/middle_word_em.text
@@ -1,0 +1,2 @@
+When middle word emphasis is disabled strings like 'self.this_long_attr' should not
+become `self.this<em>long</em>attr`.


### PR DESCRIPTION
This PR closes #38 by adding an extra to disable emphasis syntax when in the middle of a word.

The current behaviour of the library is to always convert `this_text_here` to `this<em>text</em>here`. However, this is not always desirable, as highlighted in #38.

The new `middle-word-em` extra will allow users to allow (default) or disallow this behaviour by passing `extras={'middle-word-em': True/False}`. When disabled, any emphasis will be required to have a word boundary (`r'\b'`) surrounding it.

For backwards compatibility, I've kept the default behaviour as allowing middle word emphasis. Users must explicitly disable it. Passing `extras=['middle-word-em']` will not work.