### PR TITLE
Fix angles being escaped in style blocks (issue #523)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## python-markdown2 2.4.11 (not yet released)
 
-(nothing yet)
+- [pull #524] Fix angles being escaped in style blocks (issue #523)
 
 
 ## python-markdown2 2.4.10

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -715,7 +715,7 @@ class Markdown(object):
     # _block_tags_b.  This way html5 tags are easy to keep track of.
     _html5tags = '|article|aside|header|hgroup|footer|nav|section|figure|figcaption'
 
-    _block_tags_a = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del'
+    _block_tags_a = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del|style'
     _block_tags_a += _html5tags
 
     _strict_tag_block_re = re.compile(r"""

--- a/test/tm-cases/script-and-style-blocks.html
+++ b/test/tm-cases/script-and-style-blocks.html
@@ -1,0 +1,13 @@
+<script>
+    if (1 > 2) {
+        console.log('<p>abcdef</p>');
+    }
+</script>
+
+<style>
+    pre > code {
+        font-family: 'Comic Sans MS';
+    }
+</style>
+
+<p>Some other text</p>

--- a/test/tm-cases/script-and-style-blocks.text
+++ b/test/tm-cases/script-and-style-blocks.text
@@ -1,0 +1,13 @@
+<script>
+    if (1 > 2) {
+        console.log('<p>abcdef</p>');
+    }
+</script>
+
+<style>
+    pre > code {
+        font-family: 'Comic Sans MS';
+    }
+</style>
+
+Some other text


### PR DESCRIPTION
This PR fixes #523 by adding `|style` to the `_block_tags_a` regex. This allows the contents of `<style>` tags to be hashed at the start of conversion, before any character escaping takes place, preserving the contents for the final output.