### PR TITLE
Fix #493 persisting when `code-friendly` extra enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - [pull #524] Fix angles being escaped in style blocks (issue #523)
 - [pull #527] Fix base64 images being corrupted in safe mode (issue #526)
 - [pull #529] Add `breaks` extra with ability to hard break on backslashes (issue #525)
+- [pull #532] Fix #493 persisting when `code-friendly` extra enabled
 
 ## python-markdown2 2.4.10
 

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2334,7 +2334,7 @@ class Markdown(object):
 
     _strong_re = re.compile(r"(\*\*|__)(?=\S)(.*\S)\1", re.S)
     _em_re = r"(\*|_)(?=\S)(.*?\S)\1"
-    _code_friendly_strong_re = re.compile(r"\*\*(?=\S)(.+?[*_]*)\*\*", re.S)
+    _code_friendly_strong_re = re.compile(r"\*\*(?=\S)(.*\S)\*\*", re.S)
     _code_friendly_em_re = r"\*(?=\S)(.+?)\*"
     def _do_italics_and_bold(self, text):
         if self.extras.get('middle-word-em', True) is False:


### PR DESCRIPTION
This PR fixes [this comment](https://github.com/trentm/python-markdown2/pull/531#issuecomment-1766880215) by applying the same fixes from #531 to the code friendly strong re