### PR TITLE
Maintain order of appearance in footnotes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - [pull #529] Add `breaks` extra with ability to hard break on backslashes (issue #525)
 - [pull #532] Fix #493 persisting when `code-friendly` extra enabled
 - [pull #535] Update `_slugify` to use utf-8 encoding (issue #534)
+- [pull #536] Maintain order of appearance in footnotes
 
 ## python-markdown2 2.4.10
 

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -115,7 +115,7 @@ import codecs
 import logging
 import re
 import sys
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from hashlib import sha256
 from random import randint, random
 
@@ -280,7 +280,9 @@ class Markdown(object):
 
     def _setup_extras(self):
         if "footnotes" in self.extras:
-            self.footnotes = {}
+            # order of insertion matters for footnotes. Use ordered dict for Python < 3.7
+            # https://docs.python.org/3/whatsnew/3.7.html#summary-release-highlights
+            self.footnotes = OrderedDict()
             self.footnote_ids = []
         if "header-ids" in self.extras:
             self._count_from_header_id = defaultdict(int)
@@ -2508,6 +2510,10 @@ class Markdown(object):
             if not self.footnote_return_symbol:
                 self.footnote_return_symbol = "&#8617;"
 
+            # self.footnotes is generated in _strip_footnote_definitions, which runs re.sub on the whole
+            # text. This means that the dict keys are inserted in order of appearance. Use the dict to
+            # sort footnote ids by that same order
+            self.footnote_ids.sort(key=lambda a: list(self.footnotes.keys()).index(a))
             for i, id in enumerate(self.footnote_ids):
                 if i != 0:
                     footer.append('')

--- a/test/tm-cases/footnotes_order_of_appearance.html
+++ b/test/tm-cases/footnotes_order_of_appearance.html
@@ -1,0 +1,34 @@
+<hr />
+
+<h2>title: testing the footnotes bug</h2>
+
+<p>Lorem ipsum dolor sit amet. Aliqua cillum, eu velit.<sup class="footnote-ref" id="fnref-note1"><a href="#fn-note1">3</a></sup> Velit deserunt adipiscing adipiscing ullamco exercitation.</p>
+
+<ul>
+<li>this is a list item</li>
+<li>this is a list item<sup class="footnote-ref" id="fnref-note2"><a href="#fn-note2">1</a></sup></li>
+<li>this is a list item<sup class="footnote-ref" id="fnref-note3"><a href="#fn-note3">2</a></sup></li>
+</ul>
+
+<p>Lorem ipsum dolor sit amet. Adipiscing<sup class="footnote-ref" id="fnref-note4"><a href="#fn-note4">4</a></sup> adipiscing ullamco, exercitation sint. Exercitation sint, fugiat exercitation voluptate amet.</p>
+
+<div class="footnotes">
+<hr />
+<ol>
+<li id="fn-note1">
+<p>this should be the first note&#160;<a href="#fnref-note1" class="footnoteBackLink" title="Jump back to footnote 1 in the text.">&#8617;</a></p>
+</li>
+
+<li id="fn-note2">
+<p>this should be the second note&#160;<a href="#fnref-note2" class="footnoteBackLink" title="Jump back to footnote 2 in the text.">&#8617;</a></p>
+</li>
+
+<li id="fn-note3">
+<p>this should be the third note&#160;<a href="#fnref-note3" class="footnoteBackLink" title="Jump back to footnote 3 in the text.">&#8617;</a></p>
+</li>
+
+<li id="fn-note4">
+<p>this should be the fourth note&#160;<a href="#fnref-note4" class="footnoteBackLink" title="Jump back to footnote 4 in the text.">&#8617;</a></p>
+</li>
+</ol>
+</div>

--- a/test/tm-cases/footnotes_order_of_appearance.opts
+++ b/test/tm-cases/footnotes_order_of_appearance.opts
@@ -1,0 +1,1 @@
+{"extras": ["footnotes"]}

--- a/test/tm-cases/footnotes_order_of_appearance.text
+++ b/test/tm-cases/footnotes_order_of_appearance.text
@@ -1,0 +1,15 @@
+---
+title: testing the footnotes bug
+---
+Lorem ipsum dolor sit amet. Aliqua cillum, eu velit.[^note1] Velit deserunt adipiscing adipiscing ullamco exercitation.
+
+- this is a list item
+- this is a list item[^note2]
+- this is a list item[^note3]
+
+Lorem ipsum dolor sit amet. Adipiscing[^note4] adipiscing ullamco, exercitation sint. Exercitation sint, fugiat exercitation voluptate amet.
+
+[^note1]: this should be the first note
+[^note2]: this should be the second note
+[^note3]: this should be the third note
+[^note4]: this should be the fourth note


### PR DESCRIPTION
This PR closes #533 by making sure footnotes maintain their order of appearance in the final HTML.

Previously, the order of the final footnotes list was based on the insertion order of `footnote_ids`. This array was populated as the parser processed the text and encountered footnotes. The problem is that markdown isn't processed entirely in order, leading to a disorganised footnotes list being generated.

This PR changes this by instead using the insertion order of `footnotes`, which is populated at the beginning of the conversion process by `_strip_footnote_definitions`.

The result is that the generated list of footnotes will appear in the same order as the footnote definitions.