### PR TITLE
Include HTML headers in TOC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - [pull #532] Fix #493 persisting when `code-friendly` extra enabled
 - [pull #535] Update `_slugify` to use utf-8 encoding (issue #534)
 - [pull #536] Maintain order of appearance in footnotes
+- [pull #538] Include HTML headers in TOC
 
 ## python-markdown2 2.4.10
 

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -431,15 +431,17 @@ class Markdown(object):
             text = self._a_nofollow_or_blank_links.sub(r'<\1 rel="nofollow"\2', text)
 
         if "toc" in self.extras and self._toc:
-            def toc_sort(entry):
-                '''Sort the TOC by order of appearance in text'''
-                return re.search(
-                    # header tag, any attrs, the ID, any attrs, the text, close tag
-                    r'^<(h%d).*?id=(["\'])%s\2.*>%s</\1>$' % (entry[0], entry[1], re.escape(entry[2])),
-                    text, re.M
-                ).start()
+            if self.extras['header-ids'].get('mixed'):
+                # TOC will only be out of order if mixed headers is enabled
+                def toc_sort(entry):
+                    '''Sort the TOC by order of appearance in text'''
+                    return re.search(
+                        # header tag, any attrs, the ID, any attrs, the text, close tag
+                        r'^<(h%d).*?id=(["\'])%s\2.*>%s</\1>$' % (entry[0], entry[1], re.escape(entry[2])),
+                        text, re.M
+                    ).start()
 
-            self._toc.sort(key=toc_sort)
+                self._toc.sort(key=toc_sort)
             self._toc_html = calculate_toc_html(self._toc)
 
             # Prepend toc html to output

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -431,6 +431,15 @@ class Markdown(object):
             text = self._a_nofollow_or_blank_links.sub(r'<\1 rel="nofollow"\2', text)
 
         if "toc" in self.extras and self._toc:
+            def toc_sort(entry):
+                '''Sort the TOC by order of appearance in text'''
+                return re.search(
+                    # header tag, any attrs, the ID, any attrs, the text, close tag
+                    r'^<(h%d).*?id=(["\'])%s\2.*>%s</\1>$' % (entry[0], entry[1], re.escape(entry[2])),
+                    text, re.M
+                ).start()
+
+            self._toc.sort(key=toc_sort)
             self._toc_html = calculate_toc_html(self._toc)
 
             # Prepend toc html to output

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1891,7 +1891,7 @@ class Markdown(object):
             self._toc_add_entry(h_level, header_id, h_text)
         if header_id and not id_attr:
             # '<h[digit]' + new ID + '...'
-            return text[:3] + f' id="{header_id}"' + text[3:]
+            return text[:3] + ' id="%s"' % header_id + text[3:]
         return text
 
     def _do_headers(self, text):

--- a/test/tm-cases/mixed_header_ids.html
+++ b/test/tm-cases/mixed_header_ids.html
@@ -1,0 +1,11 @@
+<h1 id="header-1">Header 1</h1>
+
+<h2 id="header-2">Header 2</h2>
+
+<h1 id="header-3">Header 3</h1>
+
+<h4 id="header-4" class="myclass">Header 4</h4>
+
+<h1 id="header-5">Header 5</h1>
+
+<h6 id="my-important-id">Header 6</h6>

--- a/test/tm-cases/mixed_header_ids.opts
+++ b/test/tm-cases/mixed_header_ids.opts
@@ -1,0 +1,1 @@
+{"extras": {"header-ids": {"mixed": True}}}

--- a/test/tm-cases/mixed_header_ids.opts
+++ b/test/tm-cases/mixed_header_ids.opts
@@ -1,1 +1,1 @@
-{"extras": {"header-ids": {"mixed": True}}}
+{"extras": {"header-ids": {"mixed": True}, "toc": None}}

--- a/test/tm-cases/mixed_header_ids.text
+++ b/test/tm-cases/mixed_header_ids.text
@@ -1,0 +1,11 @@
+# Header 1
+
+<h2>Header 2</h2>
+
+# Header 3
+
+<h4 class="myclass">Header 4</h4>
+
+# Header 5
+
+<h6 id="my-important-id">Header 6</h6>

--- a/test/tm-cases/mixed_header_ids.toc_html
+++ b/test/tm-cases/mixed_header_ids.toc_html
@@ -1,0 +1,14 @@
+<ul>
+  <li><a href="#header-1">Header 1</a>
+  <ul>
+    <li><a href="#header-2">Header 2</a></li>
+  </ul></li>
+  <li><a href="#header-3">Header 3</a>
+  <ul>
+    <li><a href="#header-4">Header 4</a></li>
+  </ul></li>
+  <li><a href="#header-5">Header 5</a>
+  <ul>
+    <li><a href="#my-important-id">Header 6</a></li>
+  </ul></li>
+</ul>


### PR DESCRIPTION
This PR closes #537 by adding the capability to parse `<h[1-6]>` tags and include their IDs in the table of contents.

It works by matching HTML header tags, checking for an `id=` attribute and then adding an entry to the TOC. If the tag does not have an ID, a new one is generated and inserted into the HTML.

Since HTML content is hashed before markdown headers are processed, this step intercepts headers in `_hash_html_block_sub` before they get hashed. This means that TOC entries are inserted out of order. To fix this, I added a function that sorts the TOC by order of appearance.
It works by taking the TOC header entry, searching the text for that header and returning the index at which it is found.

This new headers behaviour is disabled by default, and can be enabled using the new `header-ids` options dict.
```python
# new API
markdown2.markdown(text, extras={'header-ids': {'mixed': True, 'prefix': 'my-prefix'}})
# old API
markdown2.markdown(text, extras={'header-ids': 'my-prefix'})  # converted to {'prefix': 'my-prefix'} in __init__
```