### PR TITLE
Fix duplicate entries in TOC when using mixed headers

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1811,7 +1811,7 @@ class Markdown(object):
         prefix = self.extras['header-ids'].get('prefix')
         if prefix and isinstance(prefix, str):
             header_id = prefix + '-' + header_id
-        return header_id in self._count_from_header_id
+        return header_id in self._count_from_header_id or header_id in map(lambda x: x[1], self._toc)
 
     def _toc_add_entry(self, level, id, name):
         if level > self._toc_depth:

--- a/test/tm-cases/toc_duplicate_entries.html
+++ b/test/tm-cases/toc_duplicate_entries.html
@@ -1,0 +1,5 @@
+<h1 id="abc">abc</h1>
+
+<h1 id="abc-2">abc</h1>
+
+<h1 id="abc-3">abc</h1>

--- a/test/tm-cases/toc_duplicate_entries.opts
+++ b/test/tm-cases/toc_duplicate_entries.opts
@@ -1,0 +1,6 @@
+{
+  "extras": {
+    "toc": {"depth": 3},
+    "header-ids": {"mixed": True}
+  }
+}

--- a/test/tm-cases/toc_duplicate_entries.text
+++ b/test/tm-cases/toc_duplicate_entries.text
@@ -1,0 +1,3 @@
+# abc
+# abc
+# abc

--- a/test/tm-cases/toc_duplicate_entries.toc_html
+++ b/test/tm-cases/toc_duplicate_entries.toc_html
@@ -1,0 +1,5 @@
+<ul>
+  <li><a href="#abc">abc</a></li>
+  <li><a href="#abc-2">abc</a></li>
+  <li><a href="#abc-3">abc</a></li>
+</ul>


### PR DESCRIPTION
This PR contains a fix for a bug that was introduced in #538, where duplicate entries could be added to the TOC when mixed headers were in use.

The issue was in the `_header_id_exists`, where I was attempting to check that a header ID already existed. The function only checked for the header ID in `_count_from_header_id`, which contained the base ID but not the suffixed ones (eg: `abc-1`).

This PR has fixed this by also checking in the TOC itself for any header IDs that match.