### PR TITLE
Add mechanism to prevent header ID counter resetting (issue #530)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -244,7 +244,8 @@ class Markdown(object):
             if not isinstance(self.extras['header-ids'], dict):
                 self.extras['header-ids'] = {
                     'mixed': False,
-                    'prefix': self.extras['header-ids']
+                    'prefix': self.extras['header-ids'],
+                    'reset-count': True
                 }
 
         if 'break-on-newline' in self.extras:
@@ -292,7 +293,8 @@ class Markdown(object):
             self.footnotes = OrderedDict()
             self.footnote_ids = []
         if "header-ids" in self.extras:
-            self._count_from_header_id = defaultdict(int)
+            if not hasattr(self, '_count_from_header_id') or self.extras['header-ids'].get('reset-count', False):
+                self._count_from_header_id = defaultdict(int)
         if "metadata" in self.extras:
             self.metadata = {}
 


### PR DESCRIPTION
This PR closes #530 by adding a mechanism to prevent the header-ids counter from being reset between conversions. To quote from the issue:
> when using `markdown2` as part of `pdoc` [...] two identically-named headers in different docstrings (but the same module/file), [...] will generate an identical anchor

> Every time `pdoc` calls `Markdown.convert`, the counter that keeps track of header IDs is reset as part of the `_setup_extras` function

Two proposed solutions were to either stop resetting the ID counter between conversions OR to add an option to disable this behaviour. The latter has been implemented as I think it's less likely to break backwards compatibility.