### PR TITLE
Update `markdown-in-html` extra to handle markdown on same line as HTML (#546)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## python-markdown2 2.4.12 (not yet released)
 
-(nothing yet)
+- [pull #547] Update `markdown-in-html` extra to handle markdown on same line as HTML (#546)
 
 
 ## python-markdown2 2.4.11

--- a/test/tm-cases/markdown_in_html_on_same_line.html
+++ b/test/tm-cases/markdown_in_html_on_same_line.html
@@ -1,0 +1,5 @@
+<p>
+
+<p><strong>text</strong></p>
+
+</p>

--- a/test/tm-cases/markdown_in_html_on_same_line.html
+++ b/test/tm-cases/markdown_in_html_on_same_line.html
@@ -3,3 +3,21 @@
 <p><strong>text</strong></p>
 
 </p>
+
+<p>
+
+<p><strong>text</strong></p>
+
+</p>
+
+<p>
+
+<p><strong>text</strong></p>
+
+</p>
+
+<p>
+
+<p><strong>text</strong></p>
+
+</p>

--- a/test/tm-cases/markdown_in_html_on_same_line.opts
+++ b/test/tm-cases/markdown_in_html_on_same_line.opts
@@ -1,0 +1,1 @@
+{"extras": ["markdown-in-html"]}

--- a/test/tm-cases/markdown_in_html_on_same_line.text
+++ b/test/tm-cases/markdown_in_html_on_same_line.text
@@ -1,0 +1,1 @@
+<p markdown="1">**text**</p>

--- a/test/tm-cases/markdown_in_html_on_same_line.text
+++ b/test/tm-cases/markdown_in_html_on_same_line.text
@@ -1,1 +1,12 @@
 <p markdown="1">**text**</p>
+
+
+<p markdown="1">
+**text**</p>
+
+<p markdown="1">**text**
+</p>
+
+<p markdown="1">
+**text**
+</p>


### PR DESCRIPTION
This PR closes #546 by enabling the `markdown-in-html` extra to parse snippets where the markdown is on the same line as the HTML block. For example:
```html
<p markdown="1">**text**</p>
```
The fix works by detecting whether the number of matched lines is less than 3 (meaning opening tag, closing tag and content aren't all on separate lines). The first line is then split after the opening tag, and the last line is split before the closing tag.
```python
['<p markdown="1">**text**</p>']          # initial list of lines
['<p markdown="1">', '**text**</p>']      # after first line is split
['<p markdown="1">', '**text**', '</p>']  # final state
```
This allows the extra to continue as normal