### PR TITLE
Fix tables with trailing whitespace not being recognized (#549)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## python-markdown2 2.4.12 (not yet released)
 
-(nothing yet)
+- [pull #550] Fix tables with trailing whitespace not being recognized (#549)
 
 
 ## python-markdown2 2.4.11

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1241,21 +1241,21 @@ class Markdown(object):
                 (?:(?<=\n\n)|\A\n?)             # leading blank line
 
                 ^[ ]{0,%d}                      # allowed whitespace
-                (.*[|].*)  \n                   # $1: header row (at least one pipe)
+                (.*[|].*)[ ]*\n                   # $1: header row (at least one pipe)
 
                 ^[ ]{0,%d}                      # allowed whitespace
                 (                               # $2: underline row
                     # underline row with leading bar
-                    (?:  \|\ *:?-+:?\ *  )+  \|? \s? \n
+                    (?:  \|\ *:?-+:?\ *  )+  \|? \s?[ ]*\n
                     |
                     # or, underline row without leading bar
-                    (?:  \ *:?-+:?\ *\|  )+  (?:  \ *:?-+:?\ *  )? \s? \n
+                    (?:  \ *:?-+:?\ *\|  )+  (?:  \ *:?-+:?\ *  )? \s?[ ]*\n
                 )
 
                 (                               # $3: data rows
                     (?:
                         ^[ ]{0,%d}(?!\ )         # ensure line begins with 0 to less_than_tab spaces
-                        .*\|.*  \n
+                        .*\|.*[ ]*\n
                     )+
                 )
             ''' % (less_than_tab, less_than_tab, less_than_tab), re.M | re.X)

--- a/test/tm-cases/trailing_table_whitespace.html
+++ b/test/tm-cases/trailing_table_whitespace.html
@@ -1,0 +1,22 @@
+<table>
+<thead>
+<tr>
+  <th>Pros</th>
+  <th>Cons</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>Unique and refreshing take on the genre</td>
+  <td>May not resonate with all viewers</td>
+</tr>
+<tr>
+  <td>Cult classic status</td>
+  <td>Over-the-top humor may polarize audiences</td>
+</tr>
+<tr>
+  <td>Influential in launching careers</td>
+  <td>Niche appeal among comedy aficionados</td>
+</tr>
+</tbody>
+</table>

--- a/test/tm-cases/trailing_table_whitespace.opts
+++ b/test/tm-cases/trailing_table_whitespace.opts
@@ -1,0 +1,1 @@
+{"extras": ["tables"]}

--- a/test/tm-cases/trailing_table_whitespace.text
+++ b/test/tm-cases/trailing_table_whitespace.text
@@ -1,0 +1,5 @@
+| Pros                                   | Cons                                          |  
+|-----------------------------------------|------------------------------------------------|  
+| Unique and refreshing take on the genre | May not resonate with all viewers              |  
+| Cult classic status                      | Over-the-top humor may polarize audiences      |  
+| Influential in launching careers         | Niche appeal among comedy aficionados          |


### PR DESCRIPTION
This PR fixes #549 by modifying the tables regex to allow trailing whitespace on the end of each row.