### PR TITLE
Always normalise EOLs in test harness

### DIFF
--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -345,8 +345,7 @@ def norm_html_from_html(html):
         html = html.decode('utf-8')
     html = _markdown_email_link_re.sub(
         _markdown_email_link_sub, html)
-    if sys.platform == "win32":
-        html = html.replace('\r\n', '\n')
+    html = html.replace('\r\n', '\n')
     return html
 
 


### PR DESCRIPTION
This PR tweaks the test harness so that it always normalises EOLs in test files, regardless of the host OS.

This caught me when I was checking out between commits and branches. Git restored some files as `\r\n` instead of `\n` and the test suite started failing because the generated markdown didn't match, despite my local copy being in the same state as remote master.