### PR TITLE
Fix incorrect parsing of links after square brackets (#552)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - [pull #547] Update `markdown-in-html` extra to handle markdown on same line as HTML (#546)
 - [pull #550] Fix tables with trailing whitespace not being recognized (#549)
 - [pull #545] Fix multiple instances of strong emphasis (`**`) in one line (#541)
+- [pull #556] Fix incorrect parsing of links after square brackets (#552)
 
 ## python-markdown2 2.4.11
 

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1786,7 +1786,8 @@ class Markdown(object):
                             curr_pos = start_idx + 1
                     else:
                         # This id isn't defined, leave the markup alone.
-                        curr_pos = match.end()
+                        # set current pos to end of link title and continue from there
+                        curr_pos = p
                     continue
 
             # Otherwise, it isn't markup.

--- a/test/tm-cases/link_after_square_brackets.html
+++ b/test/tm-cases/link_after_square_brackets.html
@@ -1,0 +1,3 @@
+<p>[before]
+<a href="https://google.com">Some link</a>
+[after]</p>

--- a/test/tm-cases/link_after_square_brackets.text
+++ b/test/tm-cases/link_after_square_brackets.text
@@ -1,0 +1,3 @@
+[before]
+[Some link](https://google.com)
+[after]


### PR DESCRIPTION
This PR fixes #552.

The issue was with links following square brackets, eg: `[text][link](google.com)`. The link parser would hit `[text][link]` and correctly identify that this isn't a valid link. It would then set the current position counter to the end of the entire "match", which included the section containing the valid link.

I've changed it to set the current position to directly after the first square brackets, so that it picks up on the link right after