### PR TITLE
Allow cuddled tables (#557)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## python-markdown2 2.4.13 (not yet released)
 
-(nothing yet)
+- [pull #559] Allow cuddled tables (#557)
 
 
 ## python-markdown2 2.4.12

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1249,7 +1249,7 @@ class Markdown(object):
         """
         less_than_tab = self.tab_width - 1
         table_re = re.compile(r'''
-                (?:(?<=\n\n)|\A\n?)             # leading blank line
+                (?:(?<=\n)|\A\n?)             # leading blank line
 
                 ^[ ]{0,%d}                      # allowed whitespace
                 (.*[|].*)[ ]*\n                   # $1: header row (at least one pipe)

--- a/test/tm-cases/tables.html
+++ b/test/tm-cases/tables.html
@@ -130,13 +130,28 @@
 
 <p><em>Note:</em> This passes GFM, but fails in PHP-Markdown.</p>
 
-<h1>FAIL: table with cuddled leading content</h1>
+<h1>table with cuddled leading content</h1>
 
-<p>before
-| Header 1 | Header 2 |
-| -------- | -------- |
-| Cell 1 | Cell 2 |
-| Cell 3 | Cell 4 |</p>
+<p>This would have failed in &lt;=2.4.13</p>
+
+<table>
+<thead>
+<tr>
+  <th>Header 1</th>
+  <th>Header 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>Cell 1</td>
+  <td>Cell 2</td>
+</tr>
+<tr>
+  <td>Cell 3</td>
+  <td>Cell 4</td>
+</tr>
+</tbody>
+</table>
 
 <h1>single column single leading bar</h1>
 

--- a/test/tm-cases/tables.text
+++ b/test/tm-cases/tables.text
@@ -50,9 +50,9 @@ after
 *Note:* This passes GFM, but fails in PHP-Markdown.
 
 
-# FAIL: table with cuddled leading content
+# table with cuddled leading content
 
-before
+This would have failed in <=2.4.13
 | Header 1 | Header 2 |
 | -------- | -------- |
 | Cell 1 | Cell 2 |


### PR DESCRIPTION
This PR closes #557 by modifying  the tables implementation to allow tables to be cuddled to the preceding paragraph.

As mentioned in the issue, the original tables implementation appears to be based on GFM and intentionally disabled this behaviour. GFM currently allows cuddled tables, so this change just brings the extra back up to speed with that.