### PR TITLE
Fix `markdown-in-html` not always splitting HTML tags into separate lines (#558)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## python-markdown2 2.4.13 (not yet released)
 
-(nothing yet)
+- [pull #560] Fix `markdown-in-html` not always splitting HTML tags into separate lines (#558)
 
 
 ## python-markdown2 2.4.12

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -800,13 +800,17 @@ class Markdown(object):
             m = self._html_markdown_attr_re.search(first_line)
             if m:
                 lines = html.split('\n')
-                if len(lines) < 3:  # if MD is on same line as HTML
-                    lines = re.split(r'(<%s.*markdown=.*?>)' % tag, lines[0])[1:] + lines[1:]
-                    first_line = lines[0]
-                    lines = lines[:-1] + re.split(r'(</%s>.*?$)' % tag, lines[-1])[:-1]
+                # if MD is on same line as opening tag then split across two lines
+                lines = list(filter(None, (re.split(r'(<%s.*markdown=.*?>)' % tag, lines[0])))) + lines[1:]
+                # if MD on same line as closing tag, split across two lines
+                lines = lines[:-1] + list(filter(None, re.split(r'(</%s>.*?$)' % tag, lines[-1])))
+                # extract key sections of the match
+                first_line = lines[0]
                 middle = '\n'.join(lines[1:-1])
                 last_line = lines[-1]
+                # remove `markdown="1"` attr from tag
                 first_line = first_line[:m.start()] + first_line[m.end():]
+                # hash the HTML segments to protect them
                 f_key = _hash_text(first_line)
                 self.html_blocks[f_key] = first_line
                 l_key = _hash_text(last_line)

--- a/test/tm-cases/markdown_in_html_on_same_line.html
+++ b/test/tm-cases/markdown_in_html_on_same_line.html
@@ -21,3 +21,20 @@
 <p><strong>text</strong></p>
 
 </p>
+
+<p>
+
+<p><strong>text</strong>
+<strong>text</strong>
+<strong>text</strong></p>
+
+</p>
+
+<p>
+
+<p><strong>text</strong>
+<strong>text</strong>
+<strong>text</strong>
+<strong>text</strong></p>
+
+</p>

--- a/test/tm-cases/markdown_in_html_on_same_line.text
+++ b/test/tm-cases/markdown_in_html_on_same_line.text
@@ -10,3 +10,13 @@
 <p markdown="1">
 **text**
 </p>
+
+<p markdown="1">**text**
+**text**
+**text**
+</p>
+
+<p markdown="1">**text**
+**text**
+**text**
+**text**</p>


### PR DESCRIPTION
This PR fixes #558, which is a continuation from #546.

The issue is regarding `markdown-in-html` tags that are not on their own line. This issue was partially fixed in #547, but the solution was gated behind a check for `if len(lines) < 3`.
This check was based on the assumption that the snippets would look like this:
```html
<div markdown="1">Some **text**
</div>
```
This assumption completely breaks down for longer snippets, leading to HTML tags not being properly split from the surrounding markdown.

This PR fixes this by always attempting to split the HTML tags into separate lines