### PR TITLE
Fix incomplete comments in safe mode not being escaped (#563)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - [pull #559] Allow cuddled tables (#557)
 - [pull #560] Fix `markdown-in-html` not always splitting HTML tags into separate lines (#558)
+- [pull #564] Fix incomplete comments in safe mode not being escaped (#563)
 
 
 ## python-markdown2 2.4.12

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2639,7 +2639,7 @@ class Markdown(object):
         text = self._naked_gt_re.sub('&gt;', text)
         return text
 
-    _incomplete_tags_re = re.compile(r"<(/?\w+?(?!\w)\s*?.+?[\s/]+?)")
+    _incomplete_tags_re = re.compile(r"<(!--|/?\w+?(?!\w)\s*?.+?[\s/]+?)")
 
     def _encode_incomplete_tags(self, text):
         if self.safe_mode not in ("replace", "escape"):

--- a/test/tm-cases/basic_safe_mode_escape.html
+++ b/test/tm-cases/basic_safe_mode_escape.html
@@ -3,3 +3,5 @@
 <p>&lt;div&gt;yowzer!&lt;/div&gt;</p>
 
 <p>blah</p>
+
+<p><em>foo</em> &lt;!-- <em>bar</em></p>

--- a/test/tm-cases/basic_safe_mode_escape.text
+++ b/test/tm-cases/basic_safe_mode_escape.text
@@ -3,3 +3,6 @@ blah <img src="dangerous"> blah
 <div>yowzer!</div>
 
 blah
+
+
+*foo* <!-- *bar*


### PR DESCRIPTION
This PR fixes #563 by amending the `_incomplete_tags_re` to also search for HTML comments. This change means that unclosed/incomplete HTML comments will be properly escaped and won't result in the rest of the document being commented out.