### PR TITLE
Fix crash in `markdown-in-html` extra (#565)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - [pull #559] Allow cuddled tables (#557)
 - [pull #560] Fix `markdown-in-html` not always splitting HTML tags into separate lines (#558)
 - [pull #564] Fix incomplete comments in safe mode not being escaped (#563)
+- [pull #566] Fix crash in `markdown-in-html` extra (#565)
 
 
 ## python-markdown2 2.4.12

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -803,7 +803,7 @@ class Markdown(object):
                 # if MD is on same line as opening tag then split across two lines
                 lines = list(filter(None, (re.split(r'(.*?<%s.*markdown=.*?>)' % tag, lines[0])))) + lines[1:]
                 # if MD on same line as closing tag, split across two lines
-                lines = lines[:-1] + list(filter(None, re.split(r'(.*?</%s>.*?$)' % tag, lines[-1])))
+                lines = lines[:-1] + list(filter(None, re.split(r'(\s*?</%s>.*?$)' % tag, lines[-1])))
                 # extract key sections of the match
                 first_line = lines[0]
                 middle = '\n'.join(lines[1:-1])

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -791,7 +791,7 @@ class Markdown(object):
             except IndexError:
                 tag = None
 
-        tag = tag or re.match(r'^<(\S).*?>', html).group(1)
+        tag = tag or re.match(r'.*?<(\S).*?>', html).group(1)
 
         if raw and self.safe_mode:
             html = self._sanitize_html(html)
@@ -801,9 +801,9 @@ class Markdown(object):
             if m:
                 lines = html.split('\n')
                 # if MD is on same line as opening tag then split across two lines
-                lines = list(filter(None, (re.split(r'(<%s.*markdown=.*?>)' % tag, lines[0])))) + lines[1:]
+                lines = list(filter(None, (re.split(r'(.*?<%s.*markdown=.*?>)' % tag, lines[0])))) + lines[1:]
                 # if MD on same line as closing tag, split across two lines
-                lines = lines[:-1] + list(filter(None, re.split(r'(</%s>.*?$)' % tag, lines[-1])))
+                lines = lines[:-1] + list(filter(None, re.split(r'(.*?</%s>.*?$)' % tag, lines[-1])))
                 # extract key sections of the match
                 first_line = lines[0]
                 middle = '\n'.join(lines[1:-1])

--- a/test/tm-cases/markdown_in_html_in_lists.html
+++ b/test/tm-cases/markdown_in_html_in_lists.html
@@ -34,4 +34,20 @@
 
 </div></li>
 </ul></li>
+
+
+<li><p>one two</p>
+
+ <p>
+
+<p><em>NOTE:</em> opening tag is slightly indented</p>
+
+</p></li>
+<li><p>three four</p>
+
+ <p>
+
+<p><em>NOTE:</em> both tags are slightly indented</p>
+
+ </p></li>
 </ul>

--- a/test/tm-cases/markdown_in_html_in_lists.text
+++ b/test/tm-cases/markdown_in_html_in_lists.text
@@ -15,3 +15,14 @@
     ###### Block three
     Some text
     </div>
+
+
+
+- one two
+   <p markdown="1">
+  *NOTE:* opening tag is slightly indented
+  </p>
+- three four
+   <p markdown="1">
+  *NOTE:* both tags are slightly indented
+   </p>


### PR DESCRIPTION
This PR closes #565 by fixing a bug where an HTML snippet inside of a list could cause the library to crash when `markdown-in-html` is enabled.

The issue is due to how `_markdown_in_html` handles indentation.
```
- one two
   <p markdown="1">
  def
  </p>
- three four
```
In the above snippet, the HTML is placed inside a list because `_hash_html_blocks` doesn't work in lists (see #514), which means the snippet gets passed to `_do_markdown_in_html`.
The text is then dedented using `_uniform_outdent` which removes the smallest common leading indentation. Since the opening tag is indented further than the rest, it is left with a slight indentation.

The block is then passed to `_hash_html_block_sub` where multiple regular expressions expect the tag to be right at the start of the line. This causes a match to return None and the library fails to get the first match group, causing the crash.