### PR TITLE
Add `prepend` arg to toc extra (#397)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - [pull #519] Add support for custom extras
 - [pull #519] Drop Python 3.5 support
+- [pull #568] Add `prepend` arg to toc extra (#397)
 
 
 ## python-markdown2 2.4.13

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -513,7 +513,7 @@ class Markdown(object):
             self._toc_html = calculate_toc_html(self._toc)
 
             # Prepend toc html to output
-            if self.cli:
+            if self.cli or (self.extras['toc'] is not None and self.extras['toc'].get('prepend', False)):
                 text = '{}\n{}'.format(self._toc_html, text)
 
         text += "\n"

--- a/test/tm-cases/toc_prepend.html
+++ b/test/tm-cases/toc_prepend.html
@@ -1,0 +1,40 @@
+<ul>
+  <li><a href="#readme-for-blah">README for Blah</a>
+  <ul>
+    <li><a href="#introduction">Introduction</a></li>
+    <li><a href="#the-meat">The Meat</a>
+    <ul>
+      <li><a href="#beef">Beef</a>
+      <ul>
+        <li><a href="#steak">Steak</a></li>
+        <li><a href="#burgers">Burgers</a></li>
+      </ul></li>
+      <li><a href="#chicken">Chicken</a></li>
+      <li><a href="#pork">Pork</a>
+      <ul>
+        <li><a href="#mmmmmmmm-bacon">Mmmmmmmm, bacon</a></li>
+      </ul></li>
+    </ul></li>
+  </ul></li>
+  <li><a href="#at-the-top-level-again">At the <em>top</em> level again!?</a></li>
+</ul>
+
+<h1 id="readme-for-blah">README for Blah</h1>
+
+<h2 id="introduction">Introduction</h2>
+
+<h2 id="the-meat">The Meat</h2>
+
+<h3 id="beef">Beef</h3>
+
+<h5 id="steak">Steak</h5>
+
+<h5 id="burgers">Burgers</h5>
+
+<h3 id="chicken">Chicken</h3>
+
+<h3 id="pork">Pork</h3>
+
+<h4 id="mmmmmmmm-bacon">Mmmmmmmm, bacon</h4>
+
+<h1 id="at-the-top-level-again">At the <em>top</em> level again!?</h1>

--- a/test/tm-cases/toc_prepend.opts
+++ b/test/tm-cases/toc_prepend.opts
@@ -1,0 +1,1 @@
+{"extras": {"toc": {"prepend": True}}}

--- a/test/tm-cases/toc_prepend.tags
+++ b/test/tm-cases/toc_prepend.tags
@@ -1,0 +1,1 @@
+toc extra

--- a/test/tm-cases/toc_prepend.text
+++ b/test/tm-cases/toc_prepend.text
@@ -1,0 +1,20 @@
+# README for Blah
+
+## Introduction
+
+## The Meat
+
+### Beef
+
+##### Steak
+
+##### Burgers
+
+### Chicken
+
+### Pork
+
+#### Mmmmmmmm, bacon
+
+# At the *top* level again!?
+

--- a/test/tm-cases/toc_prepend.toc_html
+++ b/test/tm-cases/toc_prepend.toc_html
@@ -1,0 +1,20 @@
+<ul>
+  <li><a href="#readme-for-blah">README for Blah</a>
+  <ul>
+    <li><a href="#introduction">Introduction</a></li>
+    <li><a href="#the-meat">The Meat</a>
+    <ul>
+      <li><a href="#beef">Beef</a>
+      <ul>
+        <li><a href="#steak">Steak</a></li>
+        <li><a href="#burgers">Burgers</a></li>
+      </ul></li>
+      <li><a href="#chicken">Chicken</a></li>
+      <li><a href="#pork">Pork</a>
+      <ul>
+        <li><a href="#mmmmmmmm-bacon">Mmmmmmmm, bacon</a></li>
+      </ul></li>
+    </ul></li>
+  </ul></li>
+  <li><a href="#at-the-top-level-again">At the <em>top</em> level again!?</a></li>
+</ul>


### PR DESCRIPTION
This PR closes #397 by adding a flag that enables the TOC to be prepended to the output text.
```python
markdown2.markdown(text, extras={'toc': {'prepend': True}})
```
This option is off by default to maintain backward compatibility