### PR TITLE
Fix syntax warnings in test suite

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - [pull #519] Add support for custom extras
 - [pull #519] Drop Python 3.5 support
+- [pull #570] Fix syntax warnings in test suite
 
 
 ## python-markdown2 2.4.13

--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -14,6 +14,7 @@ import codecs
 import difflib
 import doctest
 from json import loads as json_loads
+import warnings
 
 sys.path.insert(0, join(dirname(dirname(abspath(__file__)))))
 try:
@@ -150,11 +151,14 @@ class _MarkdownTestCase(unittest.TestCase):
             opts_path = splitext(text_path)[0] + ".opts"
             if exists(opts_path):
                 try:
-                    opts = eval(open(opts_path, 'r').read())
+                    with warnings.catch_warnings(record=True) as caught_warnings:
+                        opts = eval(open(opts_path, 'r').read())
+                    for warning in caught_warnings:
+                        print("WARNING: loading %s generated warning: %s - lineno %d" % (opts_path, warning.message, warning.lineno), file=sys.stderr)
                 except Exception:
                     _, ex, _ = sys.exc_info()
                     print("WARNING: couldn't load `%s' opts file: %s" \
-                          % (opts_path, ex))
+                          % (opts_path, ex), file=sys.stderr)
 
             toc_html_path = splitext(text_path)[0] + ".toc_html"
             if not exists(toc_html_path):

--- a/test/testall.py
+++ b/test/testall.py
@@ -68,7 +68,7 @@ def testall():
             # capture and re-print stderr while process is running
             line = proc.stderr.readline().decode().strip()
             print(line, file=sys.stderr)
-            if 'WARNING:test:' in line:
+            if 'WARNING:' in line:
                 # if stderr contains a warning, save this for later
                 all_warnings.append((python, ver_str, line))
 

--- a/test/tm-cases/link_patterns.opts
+++ b/test/tm-cases/link_patterns.opts
@@ -1,8 +1,7 @@
 {"extras": ["link-patterns"],
  "link_patterns": [
-    (re.compile("recipe\s+(\d+)", re.I), r"http://code.activestate.com/recipes/\1/"),
-    (re.compile("(?:komodo\s+)?bug\s+(\d+)", re.I), r"http://bugs.activestate.com/show_bug.cgi?id=\1"),
-    (re.compile("PEP\s+(\d+)", re.I), lambda m: "http://www.python.org/dev/peps/pep-%04d/" % int(m.group(1))),
+    (re.compile(r"recipe\s+(\d+)", re.I), r"http://code.activestate.com/recipes/\1/"),
+    (re.compile(r"(?:komodo\s+)?bug\s+(\d+)", re.I), r"http://bugs.activestate.com/show_bug.cgi?id=\1"),
+    (re.compile(r"PEP\s+(\d+)", re.I), lambda m: "http://www.python.org/dev/peps/pep-%04d/" % int(m.group(1))),
  ],
 }
-

--- a/test/tm-cases/link_patterns_double_hit.opts
+++ b/test/tm-cases/link_patterns_double_hit.opts
@@ -1,7 +1,6 @@
 {"extras": ["link-patterns"],
  "link_patterns": [
     (re.compile(r'mozilla\s+bug\s+(\d+)', re.I), r'http://bugzilla.mozilla.org/show_bug.cgi?id=\1'),
-    (re.compile("(?:komodo\s+)?bug\s+(\d+)", re.I), r"http://bugs.activestate.com/show_bug.cgi?id=\1"),
+    (re.compile(r"(?:komodo\s+)?bug\s+(\d+)", re.I), r"http://bugs.activestate.com/show_bug.cgi?id=\1"),
  ],
 }
-

--- a/test/tm-cases/link_patterns_edge_cases.opts
+++ b/test/tm-cases/link_patterns_edge_cases.opts
@@ -1,7 +1,6 @@
 {"extras": ["link-patterns"],
  "link_patterns": [
-    (re.compile("Blah\s+(\d+)", re.I), r"http://foo.com/blah_blah_blah/\1"),
+    (re.compile(r"Blah\s+(\d+)", re.I), r"http://foo.com/blah_blah_blah/\1"),
     (re.compile("#([1-9][0-9]*)"), r"http://localhost/issue/\1"),
  ],
 }
-

--- a/test/tm-cases/link_patterns_escape.opts
+++ b/test/tm-cases/link_patterns_escape.opts
@@ -1,8 +1,7 @@
 {"extras": ["link-patterns"],
  "link_patterns": [
-    (re.compile("recipe\s+(\d+)", re.I), r"http://code.activestate.com/recipes/\1/"),
-    (re.compile("(?:komodo\s+)?bug\s+(\d+)", re.I), r"http://bugs.activestate.com/show_bug.cgi?id=\1"),
-    (re.compile("PEP\s+(\d+)", re.I), lambda m: "http://www.python.org/dev/peps/pep-%04d/" % int(m.group(1))),
+    (re.compile(r"recipe\s+(\d+)", re.I), r"http://code.activestate.com/recipes/\1/"),
+    (re.compile(r"(?:komodo\s+)?bug\s+(\d+)", re.I), r"http://bugs.activestate.com/show_bug.cgi?id=\1"),
+    (re.compile(r"PEP\s+(\d+)", re.I), lambda m: "http://www.python.org/dev/peps/pep-%04d/" % int(m.group(1))),
  ],
 }
-

--- a/test/tm-cases/link_patterns_hash_matching_issue287.opts
+++ b/test/tm-cases/link_patterns_hash_matching_issue287.opts
@@ -1,7 +1,7 @@
 {"extras": ["link-patterns"],
  "link_patterns": [
-    (re.compile("#(\d+)", re.I), r"https://github.com/pyfa-org/Pyfa/issues/\1"),
-    (re.compile("@(\w+)", re.I), r"https://github.com/\1"),
+    (re.compile(r"#(\d+)", re.I), r"https://github.com/pyfa-org/Pyfa/issues/\1"),
+    (re.compile(r"@(\w+)", re.I), r"https://github.com/\1"),
     (re.compile("([0-9a-f]{6,40})", re.I), r"https://github.com/pyfa-org/Pyfa/commit/\1")
     ]
 }

--- a/test/tm-cases/link_patterns_markdown_syntax.opts
+++ b/test/tm-cases/link_patterns_markdown_syntax.opts
@@ -1,5 +1,5 @@
 {"extras": ["link-patterns"],
  "link_patterns": [
-    (re.compile("recipe\s+(\d+)", re.I), r"http://code.activestate.com/recipes/\1/"),
+    (re.compile(r"recipe\s+(\d+)", re.I), r"http://code.activestate.com/recipes/\1/"),
  ],
 }


### PR DESCRIPTION
This PR fixes a number of syntax warnings being raised in the test suite regarding invalid escape sequences. I also modified the test runner to make these warnings much more visible in the future