### PR TITLE
Process inline tags as HTML blocks when they span multiple lines (#571)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - [pull #568] Add `prepend` arg to toc extra (#397)
 - [pull #569] Process HTML comments as markdown in 'escape' safe mode
 - [pull #570] Fix syntax warnings in test suite
+- [pull #572] Process inline tags as HTML blocks when they span multiple lines (#571)
 
 
 ## python-markdown2 2.4.13

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -833,6 +833,11 @@ class Markdown(object):
     _block_tags_b = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math'
     _block_tags_b += _html5tags
 
+    _span_tags = (
+        'a|abbr|acronym|b|bdo|big|br|button|cite|code|dfn|em|i|img|input|kbd|label|map|object|output|q'
+        '|samp|script|select|small|span|strong|sub|sup|textarea|time|tt|var'
+    )
+
     _liberal_tag_block_re = re.compile(r"""
         (                       # save in \1
             ^                   # start of line  (with re.M)
@@ -926,6 +931,14 @@ class Markdown(object):
 
         # Now match more liberally, simply from `\n<tag>` to `</tag>\n`
         text = self._liberal_tag_block_re.sub(hash_html_block_sub, text)
+
+        # now do the same for spans that are acting like blocks
+        # eg: an anchor split over multiple lines for readability
+        text = self._strict_tag_block_sub(
+            text, self._span_tags,
+            # inline elements can't contain block level elements, so only span gamut is required
+            lambda t: hash_html_block_sub(self._run_span_gamut(t))
+        )
 
         # Special case just for <hr />. It was easier to make a special
         # case than to make the other regex more complicated.

--- a/test/tm-cases/block_like_spans.html
+++ b/test/tm-cases/block_like_spans.html
@@ -1,0 +1,7 @@
+<a href="www.google.com">
+
+<img src="image.jpg" width="300px" height="auto" alt="Sample image"/>
+
+Some <strong>markdown</strong> text as well, but <em>no</em> block level elements, since we're still <a href="https://google.com">inside a span</a>
+
+</a>

--- a/test/tm-cases/block_like_spans.text
+++ b/test/tm-cases/block_like_spans.text
@@ -1,0 +1,7 @@
+<a href="www.google.com">
+
+<img src="image.jpg" width="300px" height="auto" alt="Sample image"/>
+
+Some **markdown** text as well, but _no_ block level elements, since we're still [inside a span](https://google.com)
+
+</a>


### PR DESCRIPTION
This PR closes #571.

Sometimes, inline tags (such as `<a>`) are written over multiple lines for readability, which makes them look alot like block elements. When spread out over multiple lines, the opening and closing tags would be detected as paragraphs and wrapped in `<p>` tags, which is invalid.

This PR avoids this by hashing these block-like spans to protect them from `_form_paragraphs`. The contents of these are run though `_run_span_gamut` in case there's any markdown in there. Since inline tags shouldn't contain block tags, we don't need to worry about processing any blocks.

The list of span tags was taken [from here](https://www.w3schools.com/htmL/html_blocks.asp).