### PR TITLE
WIP: Add extra for Lemmy spoiler format

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2765,6 +2765,19 @@ class FencedCodeBlocks(Extra):
         return self.fenced_code_block_re.sub(self.sub, text)
 
 
+class LemmySpoiler(Extra):
+    name = 'lemmy-spoiler'
+    order = (), (Stage.ITALIC_AND_BOLD,)
+
+    _lemmy_spoiler_re = re.compile(r":{3} spoiler\s+?(\S.+?\n)(.+?)\n:{3}", re.S)
+
+    def run(self, text):
+        return self._lemmy_spoiler_re.sub(r"<details><summary>\1</summary>\2</details>", text)
+
+    def test(self, text):
+        return '::: spoiler' in text
+
+
 class LinkPatterns(Extra):
     '''
     Auto-link given regex patterns in text (e.g. bug number
@@ -3328,6 +3341,7 @@ Admonitions.register()
 Breaks.register()
 CodeFriendly.register()
 FencedCodeBlocks.register()
+LemmySpoiler.register()
 LinkPatterns.register()
 MarkdownInHTML.register()
 MiddleWordEm.register()

--- a/test/tm-cases/lemmy-spoiler.html
+++ b/test/tm-cases/lemmy-spoiler.html
@@ -1,0 +1,6 @@
+<p><details><summary>this part is visible
+</summary>but this part will be hidden</details></p>
+
+<p><details><summary>this part is visible
+</summary>but this part
+and this part are hidden</details></p>

--- a/test/tm-cases/lemmy-spoiler.opts
+++ b/test/tm-cases/lemmy-spoiler.opts
@@ -1,0 +1,1 @@
+{"extras": ["lemmy-spoiler"]}

--- a/test/tm-cases/lemmy-spoiler.tags
+++ b/test/tm-cases/lemmy-spoiler.tags
@@ -1,0 +1,1 @@
+extras lemmy-spoiler

--- a/test/tm-cases/lemmy-spoiler.text
+++ b/test/tm-cases/lemmy-spoiler.text
@@ -1,0 +1,8 @@
+::: spoiler this part is visible
+but this part will be hidden
+:::
+
+::: spoiler this part is visible
+but this part
+and this part are hidden
+:::


### PR DESCRIPTION
Hello,

How would you feel about adding an extra for Lemmy's spoiler format? [Lemmy](https://join-lemmy.org/) is a Reddit clone that uses ActivityPub (it's a Fediverse app like Mastodon (which itself aims to be an alternative to Twitter)). Why Lemmy decided to use their [own format](https://join-lemmy.org/docs/users/02-media.html) for spoilers is a mystery.

The goal would be to use it with [PieFed](https://codeberg.org/rimu/pyfedi), which gets most of its content federated in from Lemmy, but recreates the HTML using Markdown2 rather than risk using the HTML they provide. (it also uses Markdown2 for locally created content too, of course)

The PieFed dev suspects that Lemmy is too niche for you to want to add it to your codebase, and we'll have to clobber the generated HTML separately, but it'll be neater if we don't have to.

Many thanks.

