### PR TITLE
Fix `html`, `head` and `body` tags being wrapped in `<p>` tags (#575)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -814,7 +814,7 @@ class Markdown(object):
     # _block_tags_b.  This way html5 tags are easy to keep track of.
     _html5tags = '|article|aside|header|hgroup|footer|nav|section|figure|figcaption'
 
-    _block_tags_a = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del|style'
+    _block_tags_a = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del|style|html|head|body'
     _block_tags_a += _html5tags
 
     _strict_tag_block_re = re.compile(r"""
@@ -2773,7 +2773,7 @@ class Latex(Extra):
 
     _single_dollar_re = re.compile(r'(?<!\$)\$(?!\$)(.*?)\$')
     _double_dollar_re = re.compile(r'\$\$(.*?)\$\$', re.DOTALL)
-    
+
     # Ways to escape
     _pre_code_block_re = re.compile(r"<pre>(.*?)</pre>", re.DOTALL) # Wraped in <pre>
     _triple_re = re.compile(r'```(.*?)```', re.DOTALL) # Wrapped in a code block ```

--- a/test/tm-cases/block_tags.html
+++ b/test/tm-cases/block_tags.html
@@ -1,0 +1,23 @@
+<html>
+
+<!-- Comment please ignore -->
+
+<!-- Multi
+line Comment
+please ignore -->
+
+
+<body>
+content here
+
+ <img src="some_img.jpg" alt="there is supposed to be an image here" width="500" height="600">
+
+Now some bullets:
+
+  * one
+  * two
+
+</body>
+
+
+</html>

--- a/test/tm-cases/block_tags.text
+++ b/test/tm-cases/block_tags.text
@@ -1,0 +1,23 @@
+<html>
+
+<!-- Comment please ignore -->
+
+<!-- Multi
+line Comment
+please ignore -->
+
+
+<body>
+content here
+
+ <img src="some_img.jpg" alt="there is supposed to be an image here" width="500" height="600">
+
+Now some bullets:
+
+  * one
+  * two
+
+</body>
+
+
+</html>


### PR DESCRIPTION
This PR fixes #575 by adding the aforementioned tags to the block tags regex. This ensures that those blocks get processed and hashed, which prevents the paragraphs system from wrapping them in unnecessary tags.