### PR TITLE
Graceful handling of broken lists when cuddled-lists extra is enabled

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2181,8 +2181,13 @@ class Markdown(object):
                     ):
                         start = li.start()
                         cuddled_list = self._do_lists(graf[start:]).rstrip("\n")
-                        assert re.match(r'^<(?:ul|ol).*?>', cuddled_list)
-                        graf = graf[:start]
+                        if re.match(r'^<(?:ul|ol).*?>', cuddled_list):
+                            graf = graf[:start]
+                        else:
+                            # Not quite a cuddled list. (See not_quite_a_list_cuddled_lists test case)
+                            # Store as a simple paragraph.
+                            graf = cuddled_list
+                            cuddled_list = None
 
                 # Wrap <p> tags.
                 graf = self._run_span_gamut(graf)

--- a/test/tm-cases/not_quite_a_list_cuddled_lists.html
+++ b/test/tm-cases/not_quite_a_list_cuddled_lists.html
@@ -1,0 +1,26 @@
+<p>So:</p>
+
+<ul>
+<li>This</li>
+<li>is</li>
+<li>a list.</li>
+</ul>
+
+<p>And:</p>
+
+<ul>
+<li><em>This</em> is</li>
+<li>a list</li>
+<li>too.</li>
+</ul>
+
+<p>However, because ASCII art can have long dash/asterisk lines let ensure that:</p>
+
+<p>- - - - - - - This isn't a list.</p>
+
+<p>* * Nor is this a list.
+-   -   - Or this.</p>
+
+<p>- - - - - - - - - - +
+ hi there ascii art
+- - - - - - - - - - +</p>

--- a/test/tm-cases/not_quite_a_list_cuddled_lists.opts
+++ b/test/tm-cases/not_quite_a_list_cuddled_lists.opts
@@ -1,0 +1,1 @@
+{"extras": ["cuddled-lists"]}

--- a/test/tm-cases/not_quite_a_list_cuddled_lists.text
+++ b/test/tm-cases/not_quite_a_list_cuddled_lists.text
@@ -1,0 +1,21 @@
+So:
+- This
+- is
+- a list.
+
+And:
+* *This* is
+* a list
+* too.
+
+However, because ASCII art can have long dash/asterisk lines let ensure that:
+
+- - - - - - - This isn't a list.
+
+* * Nor is this a list.
+-   -   - Or this.
+
+
+- - - - - - - - - - +
+ hi there ascii art
+- - - - - - - - - - +


### PR DESCRIPTION
Fixes: https://github.com/trentm/python-markdown2/issues/577

## Overview
When `"cuddled-lists"` extra is passed, if you encounter ASCII art or any invalid list such as: `- - - Test`, an `AssertionError` is thrown due to the inability to parse it as a list and therefore the result text not containing the expected list structure.

## Changes
- Instead of throwing an assertion error, we simply treat the unparsed text as the paragraph text.
- Added a regression test to reproduce the assertion error