### PR TITLE
Add type hints (#562)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 - [pull #572] Process inline tags as HTML blocks when they span multiple lines (#571)
 - [pull #573] Add new LaTeX Extra
 - [pull #576] Fix `html`, `head` and `body` tags being wrapped in `<p>` tags (#575)
+- [pull #581] Add type hints (#562)
+- [pull #581] Drop Python 3.6 and 3.7 support
 
 
 ## python-markdown2 2.4.13

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -779,8 +779,10 @@ class Markdown(object):
                 # Parse out one emacs var per line.
                 continued_for = None
                 for line in lines[:-1]:  # no var on the last line ("PREFIX End:")
-                    if prefix: line = line[len(prefix):]  # strip prefix
-                    if suffix: line = line[:-len(suffix)]  # strip suffix
+                    if prefix:
+                        line = line[len(prefix):]  # strip prefix
+                    if suffix:
+                        line = line[:-len(suffix)]  # strip suffix
                     line = line.strip()
                     if continued_for:
                         variable = continued_for
@@ -3625,7 +3627,8 @@ def _dedentlines(lines: List[str], tabsize: int = 8, skip_first_line: bool = Fal
               % (tabsize, skip_first_line))
     margin = None
     for i, line in enumerate(lines):
-        if i == 0 and skip_first_line: continue
+        if i == 0 and skip_first_line:
+            continue
         indent = 0
         for ch in line:
             if ch == ' ':
@@ -3638,16 +3641,19 @@ def _dedentlines(lines: List[str], tabsize: int = 8, skip_first_line: bool = Fal
                 break
         else:
             continue  # skip all-whitespace lines
-        if DEBUG: print("dedent: indent=%d: %r" % (indent, line))
+        if DEBUG:
+            print("dedent: indent=%d: %r" % (indent, line))
         if margin is None:
             margin = indent
         else:
             margin = min(margin, indent)
-    if DEBUG: print("dedent: margin=%r" % margin)
+    if DEBUG:
+        print("dedent: margin=%r" % margin)
 
     if margin is not None and margin > 0:
         for i, line in enumerate(lines):
-            if i == 0 and skip_first_line: continue
+            if i == 0 and skip_first_line:
+                continue
             removed = 0
             for j, ch in enumerate(line):
                 if ch == ' ':
@@ -3655,7 +3661,8 @@ def _dedentlines(lines: List[str], tabsize: int = 8, skip_first_line: bool = Fal
                 elif ch == '\t':
                     removed += tabsize - (removed % tabsize)
                 elif ch in '\r\n':
-                    if DEBUG: print("dedent: %r: EOL -> strip up to EOL" % line)
+                    if DEBUG:
+                        print("dedent: %r: EOL -> strip up to EOL" % line)
                     lines[i] = lines[i][j:]
                     break
                 else:
@@ -3688,7 +3695,7 @@ def _dedent(text: str, tabsize: int = 8, skip_first_line: bool = False) -> str:
 
     textwrap.dedent(s), but don't expand tabs to spaces
     """
-    lines = text.splitlines(1)
+    lines = text.splitlines(True)
     _dedentlines(lines, tabsize=tabsize, skip_first_line=skip_first_line)
     return ''.join(lines)
 
@@ -3901,8 +3908,10 @@ def main(argv=None):
         f = open(opts.link_patterns_file)
         try:
             for i, line in enumerate(f.readlines()):
-                if not line.strip(): continue
-                if line.lstrip().startswith("#"): continue
+                if not line.strip():
+                    continue
+                if line.lstrip().startswith("#"):
+                    continue
                 try:
                     pat, href = line.rstrip().rsplit(None, 1)
                 except ValueError:

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -132,7 +132,7 @@ else:
 _safe_mode = Literal['replace', 'escape']
 _extras_dict = Dict[str, Any]
 _extras_param = Union[List[str], _extras_dict]
-_link_patterns = Iterable[Tuple[re.Pattern, Union[str, Callable[[re.Match], str]]]]
+_link_patterns = Iterable[Tuple[re.Pattern[str], Union[str, Callable[[re.Match], str]]]]
 
 # ---- globals
 
@@ -145,7 +145,7 @@ DEFAULT_TAB_WIDTH = 4
 SECRET_SALT = bytes(randint(0, 1000000))
 # MD5 function was previously used for this; the "md5" prefix was kept for
 # backwards compatibility.
-def _hash_text(s):
+def _hash_text(s: str) -> str:
     return 'md5-' + sha256(SECRET_SALT + s.encode("utf-8")).hexdigest()[32:]
 
 # Table of hash values for escaped characters:
@@ -3487,7 +3487,7 @@ WikiTables.register()
 # ---- internal support functions
 
 
-def calculate_toc_html(toc) -> Optional[str]:
+def calculate_toc_html(toc: Union[List[Tuple[int, str, str]], None]) -> Optional[str]:
     """Return the HTML for the current TOC.
 
     This expects the `_toc` attribute to have been set on this instance.
@@ -3532,7 +3532,7 @@ class UnicodeWithAttrs(str):
 ## {{{ http://code.activestate.com/recipes/577257/ (r1)
 _slugify_strip_re = re.compile(r'[^\w\s-]')
 _slugify_hyphenate_re = re.compile(r'[-\s]+')
-def _slugify(value):
+def _slugify(value: str) -> str:
     """
     Normalizes string, converts to lowercase, removes non-alpha characters,
     and converts spaces to hyphens.
@@ -3547,8 +3547,7 @@ def _slugify(value):
 
 
 # From http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/52549
-def _curry(*args, **kwargs):
-    function, args = args[0], args[1:]
+def _curry(function: Callable, *args, **kwargs) -> Callable:
     def result(*rest, **kwrest):
         combined = kwargs.copy()
         combined.update(kwrest)
@@ -3557,7 +3556,7 @@ def _curry(*args, **kwargs):
 
 
 # Recipe: regex_from_encoded_pattern (1.0)
-def _regex_from_encoded_pattern(s):
+def _regex_from_encoded_pattern(s: str) -> re.Pattern[str]:
     """'foo'    -> re.compile(re.escape('foo'))
        '/foo/'  -> re.compile('foo')
        '/foo/i' -> re.compile('foo', re.I)
@@ -3587,7 +3586,7 @@ def _regex_from_encoded_pattern(s):
 
 
 # Recipe: dedent (0.1.2)
-def _dedentlines(lines, tabsize=8, skip_first_line=False):
+def _dedentlines(lines: List[str], tabsize: int = 8, skip_first_line: bool = False) -> List[str]:
     """_dedentlines(lines, tabsize=8, skip_first_line=False) -> dedented lines
 
         "lines" is a list of lines to dedent.
@@ -3657,7 +3656,7 @@ def _dedentlines(lines, tabsize=8, skip_first_line=False):
     return lines
 
 
-def _dedent(text, tabsize=8, skip_first_line=False):
+def _dedent(text: str, tabsize: int = 8, skip_first_line: bool = False) -> str:
     """_dedent(text, tabsize=8, skip_first_line=False) -> dedented text
 
         "text" is the text to dedent.
@@ -3700,7 +3699,7 @@ class _memoized(object):
         return self.func.__doc__
 
 
-def _xml_oneliner_re_from_tab_width(tab_width):
+def _xml_oneliner_re_from_tab_width(tab_width: int) -> re.Pattern[str]:
     """Standalone XML processing instruction regex."""
     return re.compile(r"""
         (?:
@@ -3722,7 +3721,7 @@ def _xml_oneliner_re_from_tab_width(tab_width):
 _xml_oneliner_re_from_tab_width = _memoized(_xml_oneliner_re_from_tab_width)
 
 
-def _hr_tag_re_from_tab_width(tab_width):
+def _hr_tag_re_from_tab_width(tab_width: int) -> re.Pattern[str]:
     return re.compile(r"""
         (?:
             (?<=\n\n)       # Starting after a blank line
@@ -3742,7 +3741,7 @@ def _hr_tag_re_from_tab_width(tab_width):
 _hr_tag_re_from_tab_width = _memoized(_hr_tag_re_from_tab_width)
 
 
-def _xml_escape_attr(attr, skip_single_quote=True):
+def _xml_escape_attr(attr: str, skip_single_quote: bool = True) -> str:
     """Escape the given string for use in an HTML/XML tag attribute.
 
     By default this doesn't bother with escaping `'` to `&#39;`, presuming that
@@ -3759,7 +3758,7 @@ def _xml_escape_attr(attr, skip_single_quote=True):
     return escaped
 
 
-def _xml_encode_email_char_at_random(ch):
+def _xml_encode_email_char_at_random(ch: str) -> str:
     r = random()
     # Roughly 10% raw, 45% hex, 45% dec.
     # '@' *must* be encoded. I [John Gruber] insist.

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -134,16 +134,6 @@ _extras_dict = Dict[str, Any]
 _extras_param = Union[List[str], _extras_dict]
 _link_patterns = Iterable[Tuple[re.Pattern[str], Union[str, Callable[[re.Match], str]]]]
 
-
-class _BreaksExtraOpts(TypedDict, total=False):
-    on_backslash: bool
-    on_newline: bool
-
-
-class _WavedromExtraOpts(TypedDict, total=False):
-    prefer_embed_svg: bool
-
-
 # ---- globals
 
 DEBUG = False
@@ -2725,6 +2715,14 @@ class Admonitions(Extra):
         return self.admonitions_re.sub(self.sub, text)
 
 
+class _BreaksExtraOpts(TypedDict, total=False):
+    '''Options for the `Breaks` extra'''
+    on_backslash: bool
+    '''Replace backslashes at the end of a line with <br>'''
+    on_newline: bool
+    '''Replace single new line characters with <br> when True'''
+
+
 class Breaks(Extra):
     name = 'breaks'
     order = (), (Stage.ITALIC_AND_BOLD,)
@@ -3369,6 +3367,17 @@ class Underline(Extra):
 
     def test(self, text):
         return '--' in text
+
+
+class _WavedromExtraOpts(TypedDict, total=False):
+    '''Options for the `Wavedrom` extra'''
+    prefer_embed_svg: bool
+    '''
+    Use the `wavedrom` library to convert diagrams to SVGs and embed them directly.
+    This will only work if the `wavedrom` library has been installed.
+
+    Defaults to `True`
+    '''
 
 
 class Wavedrom(Extra):

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -132,7 +132,7 @@ else:
 _safe_mode = Literal['replace', 'escape']
 _extras_dict = Dict[str, Any]
 _extras_param = Union[List[str], _extras_dict]
-_link_patterns = Iterable[Tuple[re.Pattern[str], Union[str, Callable[[re.Match], str]]]]
+_link_patterns = Iterable[Tuple[re.Pattern, Union[str, Callable[[re.Match], str]]]]
 
 # ---- globals
 
@@ -3579,7 +3579,7 @@ def _curry(function: Callable, *args, **kwargs) -> Callable:
 
 
 # Recipe: regex_from_encoded_pattern (1.0)
-def _regex_from_encoded_pattern(s: str) -> re.Pattern[str]:
+def _regex_from_encoded_pattern(s: str) -> re.Pattern:
     """'foo'    -> re.compile(re.escape('foo'))
        '/foo/'  -> re.compile('foo')
        '/foo/i' -> re.compile('foo', re.I)
@@ -3727,7 +3727,7 @@ class _memoized(object):
         return self.func.__doc__
 
 
-def _xml_oneliner_re_from_tab_width(tab_width: int) -> re.Pattern[str]:
+def _xml_oneliner_re_from_tab_width(tab_width: int) -> re.Pattern:
     """Standalone XML processing instruction regex."""
     return re.compile(r"""
         (?:
@@ -3749,7 +3749,7 @@ def _xml_oneliner_re_from_tab_width(tab_width: int) -> re.Pattern[str]:
 _xml_oneliner_re_from_tab_width = _memoized(_xml_oneliner_re_from_tab_width)
 
 
-def _hr_tag_re_from_tab_width(tab_width: int) -> re.Pattern[str]:
+def _hr_tag_re_from_tab_width(tab_width: int) -> re.Pattern:
     return re.compile(r"""
         (?:
             (?<=\n\n)       # Starting after a blank line

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -120,7 +120,7 @@ from abc import ABC, abstractmethod
 import functools
 from hashlib import sha256
 from random import randint, random
-from typing import Any, Callable, Collection, Dict, List, Literal, Optional, Sized, Tuple, Type, Union
+from typing import Any, Callable, Collection, Dict, List, Literal, Optional, Tuple, Type, TypedDict, Union
 from enum import IntEnum, auto
 
 if sys.version_info[1] < 9:
@@ -133,6 +133,16 @@ _safe_mode = Literal['replace', 'escape']
 _extras_dict = Dict[str, Any]
 _extras_param = Union[List[str], _extras_dict]
 _link_patterns = Iterable[Tuple[re.Pattern[str], Union[str, Callable[[re.Match], str]]]]
+
+
+class _BreaksExtraOpts(TypedDict, total=False):
+    on_backslash: bool
+    on_newline: bool
+
+
+class _WavedromExtraOpts(TypedDict, total=False):
+    prefer_embed_svg: bool
+
 
 # ---- globals
 
@@ -2718,6 +2728,7 @@ class Admonitions(Extra):
 class Breaks(Extra):
     name = 'breaks'
     order = (), (Stage.ITALIC_AND_BOLD,)
+    options: _BreaksExtraOpts
 
     def run(self, text):
         on_backslash = self.options.get('on_backslash', False)
@@ -3366,6 +3377,7 @@ class Wavedrom(Extra):
     '''
     name = 'wavedrom'
     order = (Stage.CODE_BLOCKS, FencedCodeBlocks), ()
+    options: _WavedromExtraOpts
 
     def test(self, text):
         match = FencedCodeBlocks.fenced_code_block_re.search(text)

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,11 @@ Intended Audience :: Developers
 License :: OSI Approved :: MIT License
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.6
-Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
+Programming Language :: Python :: 3.12
 Operating System :: OS Independent
 Topic :: Software Development :: Libraries :: Python Modules
 Topic :: Software Development :: Documentation
@@ -57,7 +56,7 @@ setup(
         ]
     },
     description="A fast and complete Python implementation of Markdown",
-    python_requires=">=3.6, <4",
+    python_requires=">=3.8, <4",
     extras_require=extras_require,
     classifiers=classifiers.strip().split("\n"),
     long_description="""markdown2: A fast and complete Python implementation of Markdown.

--- a/test/testall.py
+++ b/test/testall.py
@@ -26,8 +26,8 @@ def _gen_python_names():
     if sys.platform == "win32":
         return
 
-    # generate version numbers from python 3.5 to 3.20
-    for ver in [(3, i) for i in range(5, 20)]:
+    # generate version numbers from python 3.8 to 3.20
+    for ver in [(3, i) for i in range(8, 20)]:
         yield "python%d.%d" % ver
         if sys.platform == "win32":
             yield "python%d%d" % ver
@@ -49,7 +49,7 @@ def _gen_pythons():
 def testall():
     all_warnings = []
     for ver, python in _gen_pythons():
-        if ver < (3, 5):
+        if ver < (3, 8):
             # Don't support Python < 3.5
             continue
         ver_str = "%s.%s" % ver


### PR DESCRIPTION
This PR closes #562 by adding type hints to the library, dropping Python 3.6 and 3.7 support in the process.

3.6 and 3.7 were recently dropped from the test suite after Github removed them from CICD. It doesn't make sense to claim support for versions we don't test so I dropped them completely.

I've added type hints to pretty much every function. The `Markdown` object should be covered and most of the extras should either be explicitly covered or inferred through the type hints attached to the `Extra` base class.

All of the public API and a decent amount of the internal functions should be covered. The main gaping hole at the moment is the `extras` dict/param for the `Markdown` object. It's currently annotated as `Dict[str, any]` (after it's been massaged in the constructor), which is quite broad. Hopefully this can be improved over time as more extras are converted to the new format and their options can be better documented/annotated.