### PR TITLE
Fix fenced code blocks breaking lists (#580)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - [pull #572] Process inline tags as HTML blocks when they span multiple lines (#571)
 - [pull #573] Add new LaTeX Extra
 - [pull #576] Fix `html`, `head` and `body` tags being wrapped in `<p>` tags (#575)
+- [pull #582] Fix fenced code blocks breaking lists (#580)
 
 
 ## python-markdown2 2.4.13

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2759,7 +2759,7 @@ class FencedCodeBlocks(Extra):
 
         tags = self.tags(lexer_name)
 
-        return "\n%s%s%s\n%s\n" % (leading_indent, tags[0], codeblock, tags[1])
+        return "\n%s%s%s\n%s%s\n" % (leading_indent, tags[0], codeblock, leading_indent, tags[1])
 
     def run(self, text):
         return self.fenced_code_block_re.sub(self.sub, text)

--- a/test/tm-cases/fenced_code_blocks_simple.html
+++ b/test/tm-cases/fenced_code_blocks_simple.html
@@ -12,3 +12,16 @@
 
 <pre><code>    is indentation maintained?
 </code></pre>
+
+<p>Here's one in a list, with another one following (see #580):</p>
+
+<ul>
+<li>List 1
+<pre><code>code 1
+
+code 2
+</code></pre></li>
+</ul>
+
+<pre><code>code 3
+</code></pre>

--- a/test/tm-cases/fenced_code_blocks_simple.text
+++ b/test/tm-cases/fenced_code_blocks_simple.text
@@ -14,3 +14,16 @@ Here is one at the end of the file:
 ```
     is indentation maintained?
 ```
+
+Here's one in a list, with another one following (see #580):
+
+* List 1
+  ```
+  code 1
+
+  code 2
+  ```
+
+```
+code 3
+```


### PR DESCRIPTION
This PR fixes #580.

The `FencedCodeBlocks` extra wasn't adding the correct indentation to the closing `</code></pre>` tags, which would break the HTML when inside lists.