### PR TITLE
Fix #583 by tweaking incomplete tag regex

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2342,7 +2342,7 @@ class Markdown(object):
         text = self._naked_gt_re.sub('&gt;', text)
         return text
 
-    _incomplete_tags_re = re.compile(r"<(!--|/?\w+?(?!\w)\s*?.+?[\s/]+?)")
+    _incomplete_tags_re = re.compile(r"<(!--|/?\w+?(?!\w)\s*?.+?(?:[\s/]+?|$))")
 
     def _encode_incomplete_tags(self, text: str) -> str:
         if self.safe_mode not in ("replace", "escape"):

--- a/test/tm-cases/issue341_xss.html
+++ b/test/tm-cases/issue341_xss.html
@@ -1,5 +1,5 @@
 <p>Example 1:
-<ftp:<a href="#">[HTML_REMOVED]alert(1);//</a>&gt;<ftp:<a href="#">[HTML_REMOVED]</a>&gt;</p>
+&lt;ftp:<a href="#">[HTML_REMOVED]alert(1);//</a>&gt;&lt;ftp:<a href="#">[HTML_REMOVED]</a>&gt;</p>
 
 <p>Example 2:
 &lt;http://g<!s://q?<!-&lt;<a href="http://g">[HTML_REMOVED]alert(1);/\*</a>->a>&lt;http://g<!s://g.c?<!-&lt;<a href="http://g">a\\*/[HTML_REMOVED]alert(1);/*</a>->a></p>

--- a/test/tm-cases/issue583_xss.html
+++ b/test/tm-cases/issue583_xss.html
@@ -1,0 +1,1 @@
+<p>&lt;img onerror=alert("hi")[HTML_REMOVED] src=a</p>

--- a/test/tm-cases/issue583_xss.opts
+++ b/test/tm-cases/issue583_xss.opts
@@ -1,0 +1,1 @@
+{'safe_mode': 'replace'}

--- a/test/tm-cases/issue583_xss.text
+++ b/test/tm-cases/issue583_xss.text
@@ -1,0 +1,1 @@
+<img onerror=alert("hi")<a> src=a


### PR DESCRIPTION
This PR closes #583 by tweaking the incomplete tags regex. It now accounts for the token not having a trailing space.

That issue highlighted some larger issues  that this PR doesn't address, such as some assumptions made in the HTML span hasher. That will have to be looked into separately but this PR should patch the highlighted case