### PR TITLE
Fix underscores within bold text getting emphasized (#589)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## python-markdown2 2.5.1 (not yet released)
 
-(nothing yet)
+- [pull 590] Fix underscores within bold text getting emphasized (#589)
 
 
 ## python-markdown2 2.5.0

--- a/test/tm-cases/code_friendly_bold.html
+++ b/test/tm-cases/code_friendly_bold.html
@@ -1,0 +1,1 @@
+<p><strong>bold_but_not_emphasized</strong></p>

--- a/test/tm-cases/code_friendly_bold.opts
+++ b/test/tm-cases/code_friendly_bold.opts
@@ -1,0 +1,1 @@
+{"extras": ["code-friendly"]}

--- a/test/tm-cases/code_friendly_bold.text
+++ b/test/tm-cases/code_friendly_bold.text
@@ -1,0 +1,1 @@
+**bold_but_not_emphasized**


### PR DESCRIPTION
This PR fixes #589, which saw a regression for the following snippet:
```
**bold_but_not_emphasized**
```
This regression was introduced in fcaadfe when the `code-friendly` extra was converted to the new `Extra` format.

Prior to this change we had two different versions of the strong/em regexes and we'd run one or the other. That's not possible in the new format so the `CodeFriendly` extra runs before italics and bold and hashes text to protect it from the regex.

Currently it only hashes text if it's using the `_underscore bold syntax_`, but for `*star syntax*` it doesn't check if the text contains any underscores, which is how this can slip through.

I've modified the extra to check for underscores within the bold text. It will now hash that text, protecting it from the strong/em regex, and it will be unhashed afterwards.