### PR TITLE
Add `Alerts` extra

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2746,7 +2746,7 @@ class Alerts(Extra):
 
     def sub(self, match: re.Match) -> str:
         typ = match["type"].lower()
-        heading = f"<em>{match["type"].title()}</em>"
+        heading = f"<em>{match['type'].title()}</em>"
         contents = match["contents"].strip()
         if match["closing_tag"]:
             return f'<div class="alert {typ}">\n{heading}\n{contents}\n</div>'

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2722,6 +2722,41 @@ class Admonitions(Extra):
         return self.admonitions_re.sub(self.sub, text)
 
 
+class Alerts(Extra):
+    '''
+    Markdown Alerts as per
+    https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
+    '''
+
+    name = 'alerts'
+    order = (), (Stage.BLOCK_QUOTES, )
+
+    alert_re = re.compile(r'''
+        <blockquote>\s*
+        <p>
+        \[!(?P<type>NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]
+        (?P<closing_tag></p>[ \t]*\n?)?
+        (?P<contents>[\s\S]+?)
+        </blockquote>
+    ''', re.X
+    )
+
+    def test(self, text):
+        return "<blockquote>" in text
+
+    def sub(self, match: re.Match) -> str:
+        typ = match["type"].lower()
+        heading = f"<em>{match["type"].title()}</em>"
+        contents = match["contents"].strip()
+        if match["closing_tag"]:
+            return f'<div class="alert {typ}">\n{heading}\n{contents}\n</div>'
+        else:
+            return f'<div class="alert {typ}">\n{heading}\n<p>{contents}\n</div>'
+
+    def run(self, text):
+        return self.alert_re.sub(self.sub, text)
+
+
 class _BreaksExtraOpts(TypedDict, total=False):
     '''Options for the `Breaks` extra'''
     on_backslash: bool
@@ -3490,6 +3525,7 @@ class WikiTables(Extra):
 
 # Register extras
 Admonitions.register()
+Alerts.register()
 Breaks.register()
 CodeFriendly.register()
 FencedCodeBlocks.register()

--- a/test/tm-cases/alerts.html
+++ b/test/tm-cases/alerts.html
@@ -1,0 +1,24 @@
+<div class="alert note">
+<em>Note</em>
+<p>Useful information that users should know, even when skimming content.</p>
+</div>
+
+<div class="alert tip">
+<em>Tip</em>
+<p>Helpful advice for doing things better or more easily.</p>
+</div>
+
+<div class="alert important">
+<em>Important</em>
+<p>Key information users need to know to achieve their goal.</p>
+</div>
+
+<div class="alert warning">
+<em>Warning</em>
+<p>Urgent info that needs immediate user attention to avoid problems.</p>
+</div>
+
+<div class="alert caution">
+<em>Caution</em>
+<p>Advises about risks or negative outcomes of certain actions.</p>
+</div>

--- a/test/tm-cases/alerts.opts
+++ b/test/tm-cases/alerts.opts
@@ -1,0 +1,1 @@
+{"extras": ["alerts"]}

--- a/test/tm-cases/alerts.text
+++ b/test/tm-cases/alerts.text
@@ -1,0 +1,15 @@
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+>
+> Advises about risks or negative outcomes of certain actions.


### PR DESCRIPTION
This PR adds an `Alert` extra, which can be used to render [GitHub Markdown Alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).