### PR TITLE
Add language to HTML output in pygments code blocks (#379)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2024,7 +2024,9 @@ class Markdown(object):
                 """A function for use in a Pygments Formatter which
                 wraps in <code> tags.
                 """
-                yield 0, "<code>"
+                # class format following what we do for highlight-js
+                # eg: class="python language-python"
+                yield 0, f'<code class="{lang_class} language-{lang_class}">'
                 for tup in inner:
                     yield tup
                 yield 0, "</code>"
@@ -2044,6 +2046,7 @@ class Markdown(object):
                     # pygments < 2.12
                     return self._wrap_div(self._add_newline(self._wrap_pre(self._wrap_code(source))))
 
+        lang_class = lexer.name.lower().replace(' ', '-')
         formatter_opts.setdefault("cssclass", "codehilite")
         formatter = HtmlCodeFormatter(**formatter_opts)
         return pygments.highlight(codeblock, lexer, formatter)

--- a/test/tm-cases/admonitions_with_fenced_code_blocks.html
+++ b/test/tm-cases/admonitions_with_fenced_code_blocks.html
@@ -2,7 +2,7 @@
     <strong>note</strong>
     <p>Admonitions are able to contain fenced code blocks</p>
     <div class="codehilite">
-    <pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;like so&#39;</span><span class="p">)</span>
+    <pre><span></span><code class="python language-python"><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;like so&#39;</span><span class="p">)</span>
     </code></pre>
     </div>
 </aside>
@@ -10,25 +10,25 @@
 <aside class="admonition warning">
     <strong>warning</strong>
     <div class="codehilite">
-    <pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;Consecutive blocks should also be fine&#39;</span><span class="p">)</span>
+    <pre><span></span><code class="python language-python"><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;Consecutive blocks should also be fine&#39;</span><span class="p">)</span>
     </code></pre>
     </div>
     <div class="codehilite">
-    <pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;Even though fenced code blocks wrap themselves in newlines&#39;</span><span class="p">)</span>
+    <pre><span></span><code class="python language-python"><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;Even though fenced code blocks wrap themselves in newlines&#39;</span><span class="p">)</span>
     </code></pre>
     </div>
     <aside class="admonition hint">
         <strong>hint</strong>
         <em>It should also work nested</em>
         <div class="codehilite">
-        <pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;ok&#39;</span><span class="p">)</span>
+        <pre><span></span><code class="python language-python"><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;ok&#39;</span><span class="p">)</span>
         </code></pre>
         </div>
     </aside>
 </aside>
 
 <div class="codehilite">
-<pre><span></span><code><span class="c1"># admonitions WITHIN fenced code blocks should NOT be rendered</span>
+<pre><span></span><code class="python language-python"><span class="c1"># admonitions WITHIN fenced code blocks should NOT be rendered</span>
 <span class="o">..</span> <span class="n">attention</span><span class="p">::</span> <span class="n">title</span>
    <span class="n">body</span>
 </code></pre>

--- a/test/tm-cases/empty_fenced_code_blocks.html
+++ b/test/tm-cases/empty_fenced_code_blocks.html
@@ -1,5 +1,5 @@
 <div class="codehilite">
-<pre><span></span><code>
+<pre><span></span><code class="bash language-bash">
 </code></pre>
 </div>
 
@@ -9,7 +9,7 @@
 <p>Pygments removes the empty line whitespace from the next code block</p>
 
 <div class="codehilite">
-<pre><span></span><code>
+<pre><span></span><code class="bash language-bash">
 </code></pre>
 </div>
 

--- a/test/tm-cases/fenced_code_blocks_issue355.html
+++ b/test/tm-cases/fenced_code_blocks_issue355.html
@@ -1,5 +1,5 @@
 <div class="codehilite">
-<pre><span></span><code><span class="n">some</span> <span class="n">code</span> <span class="n">block</span>
+<pre><span></span><code class="python language-python"><span class="n">some</span> <span class="n">code</span> <span class="n">block</span>
 </code></pre>
 </div>
 

--- a/test/tm-cases/fenced_code_blocks_issue426.html
+++ b/test/tm-cases/fenced_code_blocks_issue426.html
@@ -15,7 +15,7 @@
 <li><p><code>ContextMixin</code> defines the method <code>get_context_data</code>:</p>
 
 <div class="codehilite">
-<pre><span></span><code><span class="k">def</span> <span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+<pre><span></span><code class="python language-python"><span class="k">def</span> <span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
     <span class="n">kwargs</span><span class="o">.</span><span class="n">setdefault</span><span class="p">(</span><span class="s1">&#39;view&#39;</span><span class="p">,</span> <span class="bp">self</span><span class="p">)</span>
     <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">extra_context</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
         <span class="n">kwargs</span><span class="o">.</span><span class="n">update</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">extra_context</span><span class="p">)</span>
@@ -26,7 +26,7 @@
 <p>So when overriding one must be careful to extends <code>super</code>'s <code>kwargs</code>:</p>
 
 <div class="codehilite">
-<pre><span></span><code><span class="k">def</span> <span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+<pre><span></span><code class="python language-python"><span class="k">def</span> <span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
     <span class="n">kwargs</span> <span class="o">=</span> <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="n">get_context_data</span><span class="p">(</span><span class="o">**</span><span class="n">kwargs</span><span class="p">)</span>
     <span class="n">kwargs</span><span class="p">[</span><span class="s1">&#39;page_title&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s2">&quot;Documentation&quot;</span>
     <span class="k">return</span> <span class="n">kwargs</span>

--- a/test/tm-cases/fenced_code_blocks_issue462.html
+++ b/test/tm-cases/fenced_code_blocks_issue462.html
@@ -1,7 +1,7 @@
 <h1>Section 1</h1>
 
 <div class="codehilite">
-<pre><span></span><code><span class="n">x</span> <span class="o">=</span> <span class="mi">1</span>
+<pre><span></span><code class="python language-python"><span class="n">x</span> <span class="o">=</span> <span class="mi">1</span>
 </code></pre>
 </div>
 

--- a/test/tm-cases/fenced_code_blocks_leading_lang_space.html
+++ b/test/tm-cases/fenced_code_blocks_leading_lang_space.html
@@ -1,5 +1,5 @@
 <div class="codehilite">
-<pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+<pre><span></span><code class="python language-python"><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
     <span class="nb">print</span> <span class="s2">&quot;hi&quot;</span>
 </code></pre>
 </div>

--- a/test/tm-cases/fenced_code_blocks_safe_highlight.html
+++ b/test/tm-cases/fenced_code_blocks_safe_highlight.html
@@ -1,5 +1,5 @@
 <div class="codehilite">
-<pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+<pre><span></span><code class="python language-python"><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
     <span class="nb">print</span> <span class="s2">&quot;hi&quot;</span>
 </code></pre>
 </div>
@@ -9,7 +9,7 @@ syntax coloring, if <code>pygments</code> is installed. See
 <a href="http://github.github.com/github-flavored-markdown/">http://github.github.com/github-flavored-markdown/</a>.</p>
 
 <div class="codehilite">
-<pre><span></span><code><span class="k">def</span><span class="w"> </span><span class="nf">foo</span>
+<pre><span></span><code class="ruby language-ruby"><span class="k">def</span><span class="w"> </span><span class="nf">foo</span>
 <span class="w">    </span><span class="nb">puts</span><span class="w"> </span><span class="s2">&quot;hi&quot;</span>
 <span class="k">end</span>
 </code></pre>

--- a/test/tm-cases/fenced_code_blocks_syntax_highlighting.html
+++ b/test/tm-cases/fenced_code_blocks_syntax_highlighting.html
@@ -1,5 +1,5 @@
 <div class="codehilite">
-<pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+<pre><span></span><code class="python language-python"><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
     <span class="nb">print</span> <span class="s2">&quot;hi&quot;</span>
 </code></pre>
 </div>
@@ -9,7 +9,7 @@ syntax coloring, if <code>pygments</code> is installed. See
 <a href="http://github.github.com/github-flavored-markdown/">http://github.github.com/github-flavored-markdown/</a>.</p>
 
 <div class="codehilite">
-<pre><span></span><code><span class="k">def</span><span class="w"> </span><span class="nf">foo</span>
+<pre><span></span><code class="ruby language-ruby"><span class="k">def</span><span class="w"> </span><span class="nf">foo</span>
 <span class="w">    </span><span class="nb">puts</span><span class="w"> </span><span class="s2">&quot;hi&quot;</span>
 <span class="k">end</span>
 </code></pre>

--- a/test/tm-cases/fenced_code_blocks_syntax_indentation.html
+++ b/test/tm-cases/fenced_code_blocks_syntax_indentation.html
@@ -1,5 +1,5 @@
 <div class="codehilite">
-<pre><span></span><code><span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>
+<pre><span></span><code class="python language-python"><span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>
     <span class="nb">print</span> <span class="s2">&quot;foo&quot;</span>
 
     <span class="nb">print</span> <span class="s2">&quot;bar&quot;</span>

--- a/test/tm-cases/hash_nested_html_blocks.html
+++ b/test/tm-cases/hash_nested_html_blocks.html
@@ -1,6 +1,6 @@
 <div class="enclosing">
 <div class="codehilite">
-<pre><span></span><code><span class="n">x</span> <span class="o">=</span> <span class="mi">1</span>
+<pre><span></span><code class="python language-python"><span class="n">x</span> <span class="o">=</span> <span class="mi">1</span>
 </code></pre>
 </div>
 

--- a/test/tm-cases/issue276_fenced_code_blocks_in_lists.html
+++ b/test/tm-cases/issue276_fenced_code_blocks_in_lists.html
@@ -13,7 +13,7 @@
 <p>empty codeblock just for sh*ts and giggles</p>
 
 <div class="codehilite">
-<pre><span></span><code><span class="n">test</span> <span class="k">with</span> <span class="n">language</span> <span class="nb">set</span>
+<pre><span></span><code class="python language-python"><span class="n">test</span> <span class="k">with</span> <span class="n">language</span> <span class="nb">set</span>
 </code></pre>
 </div>
 

--- a/test/tm-cases/pyshell_and_fenced_code_blocks.html
+++ b/test/tm-cases/pyshell_and_fenced_code_blocks.html
@@ -3,7 +3,7 @@
 <p>Some examples:</p>
 
 <div class="codehilite">
-<pre><span></span><code><span class="gp">&gt;&gt;&gt; </span><span class="n">nprint</span><span class="p">(</span><span class="mi">9876543210</span><span class="p">)</span>
+<pre><span></span><code class="python-console-session language-python-console-session"><span class="gp">&gt;&gt;&gt; </span><span class="n">nprint</span><span class="p">(</span><span class="mi">9876543210</span><span class="p">)</span>
 <span class="go">&#39;9 876 543 210&#39;</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">nprint</span><span class="p">(</span><span class="mi">987654321</span><span class="p">,</span> <span class="n">period</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">delimiter</span><span class="o">=</span><span class="s2">&quot;,&quot;</span><span class="p">)</span>
 <span class="go">&#39;9,8,7,6,5,4,3,2,1,0&#39;</span>
@@ -13,7 +13,7 @@
 <p>Indented a bit:</p>
 
 <div class="codehilite">
-<pre><span></span><code><span class="gp">&gt;&gt;&gt; </span><span class="mi">1</span> <span class="o">+</span> <span class="mi">1</span>
+<pre><span></span><code class="python-console-session language-python-console-session"><span class="gp">&gt;&gt;&gt; </span><span class="mi">1</span> <span class="o">+</span> <span class="mi">1</span>
 <span class="go">2</span>
 </code></pre>
 </div>
@@ -22,7 +22,7 @@
 
 <blockquote>
   <div class="codehilite">
-<pre><span></span><code><span class="gp">&gt;&gt;&gt; </span><span class="mi">1</span> <span class="o">+</span> <span class="mi">1</span>
+<pre><span></span><code class="python-console-session language-python-console-session"><span class="gp">&gt;&gt;&gt; </span><span class="mi">1</span> <span class="o">+</span> <span class="mi">1</span>
 <span class="go">2</span>
 </code></pre>
   </div>
@@ -31,7 +31,7 @@
 <p>Cuddled to previous para (and at end of document):</p>
 
 <div class="codehilite">
-<pre><span></span><code><span class="gp">&gt;&gt;&gt; </span><span class="mi">2</span> <span class="o">+</span> <span class="mi">2</span>
+<pre><span></span><code class="python-console-session language-python-console-session"><span class="gp">&gt;&gt;&gt; </span><span class="mi">2</span> <span class="o">+</span> <span class="mi">2</span>
 <span class="go">4</span>
 </code></pre>
 </div>

--- a/test/tm-cases/quoted_fenced_code_blocks_whitespace_around_indented_lines.html
+++ b/test/tm-cases/quoted_fenced_code_blocks_whitespace_around_indented_lines.html
@@ -2,7 +2,7 @@
 
 <blockquote>
   <div class="codehilite">
-<pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+<pre><span></span><code class="python language-python"><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
     <span class="nb">print</span><span class="p">()</span>
 
     <span class="nb">print</span><span class="p">()</span>


### PR DESCRIPTION
This PR closes #379 by including the language name in the HTML output for Pygments fenced code blocks.

Pygments code blocks will now use the lexer name to decide the class for `<code>` tags like so:
```html
<code class="python language-python">
```

The behaviour of this change is consistent with the behaviour of `highlightjs-lang`