### PR TITLE
Use urandom for SECRET_SALT

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -122,6 +122,7 @@ from hashlib import sha256
 from random import randint, random
 from typing import Any, Callable, Collection, Dict, List, Literal, Optional, Tuple, Type, TypedDict, Union
 from enum import IntEnum, auto
+from os import urandom
 
 if sys.version_info[1] < 9:
     from typing import Iterable
@@ -142,7 +143,7 @@ log = logging.getLogger("markdown")
 DEFAULT_TAB_WIDTH = 4
 
 
-SECRET_SALT = bytes(randint(0, 1000000))
+SECRET_SALT = urandom(16)
 # MD5 function was previously used for this; the "md5" prefix was kept for
 # backwards compatibility.
 def _hash_text(s: str) -> str:


### PR DESCRIPTION
See #599 for the issue.

This PR generates the `SECRET_SALT` with urandom instead of bytes(randint(0, 1000000)), making the SALT realistically unguessable, and also improving the performance a bit.

I'm using `urandom` instead of `secrets` because it'll keep the library compatible with its current supported Python versions (3.5+).