### PR TITLE
Fix XSS issue in safe mode (#601)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - [pull #590] Fix underscores within bold text getting emphasized (#589)
 - [pull #591] Add Alerts extra
 - [pull #595] Fix img alt text being processed as markdown (#594)
+- [pull #602] Fix XSS issue in safe mode (#601)
 
 
 ## python-markdown2 2.5.0

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1260,8 +1260,13 @@ class Markdown(object):
             (?:
                 # tag
                 </?
-                (?:\w+)                                     # tag name
-                (?:\s+(?:[\w-]+:)?[\w-]+=(?:".*?"|'.*?'))*  # attributes
+                (?:\w+)         # tag name
+                (?:             # attributes
+                    \s+                           # whitespace after tag
+                    (?:[^\t<>"'=/]+:)?
+                    [^<>"'=/]+=                   # attr name
+                    (?:".*?"|'.*?'|[^<>"'=/\s]+)  # value, quoted or unquoted. If unquoted, no spaces allowed
+                )*
                 \s*/?>
                 |
                 # auto-link (e.g., <http://www.activestate.com/>)

--- a/test/tm-cases/issue601_xss.html
+++ b/test/tm-cases/issue601_xss.html
@@ -1,0 +1,1 @@
+<p>&lt;img src=# onerror="alert()"&gt;&lt;/p&gt;</p>

--- a/test/tm-cases/issue601_xss.opts
+++ b/test/tm-cases/issue601_xss.opts
@@ -1,0 +1,1 @@
+{"safe_mode": "escape"}

--- a/test/tm-cases/issue601_xss.text
+++ b/test/tm-cases/issue601_xss.text
@@ -1,0 +1,1 @@
+<img src=# onerror="alert()"></p>


### PR DESCRIPTION
This PR fixes #601 by making the HTML tokenisation regex more lenient.

Currently, the regex matches HTML tags and their attributes, using `[\w-]` for the attribute name. However, in the [HTML spec](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2) it says:
> Attribute names must consist of one or more characters other than [controls](https://infra.spec.whatwg.org/#control), U+0020 SPACE, U+0022 ("), U+0027 ('), U+003E (>), U+002F (/), U+003D (=), and [noncharacters](https://infra.spec.whatwg.org/#noncharacter)

The current character class being used does not include all these possibilities so I've updated it to instead exclude these banned characters: `[^<>"'=/]`.

I also tweaked how the attribute values are matched. The current regex only allows for quoted values, which lets `src=# onerror=alert()` slip past. I've added another clause in the regex that matches unquoted attr values as long as they don't contain a space (because that would count as the next attribute)