### PR TITLE
Fix XSS injection in image URLs (#603)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - [pull #590] Fix underscores within bold text getting emphasized (#589)
 - [pull #591] Add Alerts extra
 - [pull #595] Fix img alt text being processed as markdown (#594)
+- [pull #604] Fix XSS injection in image URLs (#603)
 
 
 ## python-markdown2 2.5.0

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1354,9 +1354,23 @@ class Markdown(object):
             is_html_markup = not is_html_markup
         return ''.join(tokens)
 
-    def _unhash_html_spans(self, text: str) -> str:
-        for key, sanitized in list(self.html_spans.items()):
-            text = text.replace(key, sanitized)
+    def _unhash_html_spans(self, text: str, spans=True, code=False) -> str:
+        '''
+        Recursively unhash a block of text
+
+        Args:
+            spans: unhash anything from `self.html_spans`
+            code: unhash code blocks
+        '''
+        orig = ''
+        while text != orig:
+            if spans:
+                for key, sanitized in list(self.html_spans.items()):
+                    text = text.replace(key, sanitized)
+            if code:
+                for code, key in list(self._code_table.items()):
+                    text = text.replace(key, code)
+            orig = text
         return text
 
     def _sanitize_html(self, s: str) -> str:
@@ -1582,8 +1596,9 @@ class Markdown(object):
 
                     # We've got to encode these to avoid conflicting
                     # with italics/bold.
-                    url = url.replace('*', self._escape_table['*']) \
-                             .replace('_', self._escape_table['_'])
+                    url = self._unhash_html_spans(url, code=True) \
+                              .replace('*', self._escape_table['*']) \
+                              .replace('_', self._escape_table['_'])
                     if title:
                         title_str = ' title="%s"' % (
                             _xml_escape_attr(title)

--- a/test/tm-cases/issue603_xss.html
+++ b/test/tm-cases/issue603_xss.html
@@ -1,0 +1,4 @@
+<p><img src="code&gt;&quot; onerror=alert()//&lt;/code" alt="" /></p>
+
+<p><img src="&quot; onerror=alert()//" alt="" />
+<a href="#"></a></p>

--- a/test/tm-cases/issue603_xss.html
+++ b/test/tm-cases/issue603_xss.html
@@ -1,4 +1,6 @@
 <p><img src="code&gt;&quot; onerror=alert()//&lt;/code" alt="" /></p>
 
 <p><img src="&quot; onerror=alert()//" alt="" />
-<a href="#"></a></p>
+<a href="#"></a>
+<img src="`&quot; onerror=alert()//`" alt="" />
+<img src="&lt;code&gt;&quot; onerror=alert()//&lt;code&gt;" alt="" /></p>

--- a/test/tm-cases/issue603_xss.opts
+++ b/test/tm-cases/issue603_xss.opts
@@ -1,0 +1,1 @@
+{"safe_mode": "escape"}

--- a/test/tm-cases/issue603_xss.text
+++ b/test/tm-cases/issue603_xss.text
@@ -1,0 +1,8 @@
+![](`" onerror=alert()//`)
+
+
+![][XSS]
+[][XSS]
+
+
+[XSS]: " onerror=alert()//

--- a/test/tm-cases/issue603_xss.text
+++ b/test/tm-cases/issue603_xss.text
@@ -3,6 +3,10 @@
 
 ![][XSS]
 [][XSS]
+![][XSS2]
+![][XSS3]
 
 
 [XSS]: " onerror=alert()//
+[XSS2]: `" onerror=alert()//`
+[XSS3]: <code>" onerror=alert()//<code>


### PR DESCRIPTION
This PR fixes #603.

The issue was with image URLs and code blocks. Putting a code block in the image URL (``![](`code here`)``) caused the URL to be hashed and protected from further modification. Code blocks are expected to contain URL unsafe characters like quotes so this is normal.

The problem was that in `_protect_url`, we attempt to escape any URL unsafe characters, but since the URL has been hashed it is ineffective.

This PR fixes this by completely unhashing the image URL before passing it to `_protect_url`, which allows special characters to be escaped