### PR TITLE
Add support for Python 3.13, drop EOL 3.8

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os:
           - ubuntu-20.04
           - macos-latest

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
           - macos-latest
           - windows-latest
     steps:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -9,15 +9,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os:
           - ubuntu-20.04
           - macos-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## python-markdown2 2.5.2 (not yet released)
 
-(nothing yet)
+- [pull #605] Add support for Python 3.13, drop EOL 3.8
 
 
 ## python-markdown2 2.5.1

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -120,16 +120,12 @@ import sys
 from collections import defaultdict, OrderedDict
 from abc import ABC, abstractmethod
 import functools
+from collections.abc import Iterable
 from hashlib import sha256
 from random import random
 from typing import Any, Callable, Collection, Dict, List, Literal, Optional, Tuple, Type, TypedDict, Union
 from enum import IntEnum, auto
 from os import urandom
-
-if sys.version_info[1] < 9:
-    from typing import Iterable
-else:
-    from collections.abc import Iterable
 
 # ---- type defs
 _safe_mode = Literal['replace', 'escape']

--- a/perf/gen_perf_cases.py
+++ b/perf/gen_perf_cases.py
@@ -104,9 +104,9 @@ def _markdown_from_aspn_html(html):
             title = None
         escaped_href = href.replace('(', '\\(').replace(')', '\\)')
         if title is None:
-            replacement = '[%s](%s)' % (content, escaped_href)
+            replacement = '[{}]({})'.format(content, escaped_href)
         else:
-            replacement = '[%s](%s "%s")' % (content, escaped_href, 
+            replacement = '[{}]({} "{}")'.format(content, escaped_href, 
                                              title.replace('"', "'"))
         markdown = markdown[:start] + replacement + markdown[end:]
         

--- a/perf/perf.py
+++ b/perf/perf.py
@@ -34,7 +34,7 @@ def time_markdown_py(cases_dir, repeat):
     for i in range(repeat):
         start = clock()
         for path in glob(join(cases_dir, "*.text")):
-            f = open(path, 'r')
+            f = open(path)
             content = f.read()
             f.close()
             try:
@@ -59,7 +59,7 @@ def time_markdown2_py(cases_dir, repeat):
     for i in range(repeat):
         start = clock()
         for path in glob(join(cases_dir, "*.text")):
-            f = open(path, 'r')
+            f = open(path)
             content = f.read()
             f.close()
             markdowner.convert(content)

--- a/perf/strip_cookbook_data.py
+++ b/perf/strip_cookbook_data.py
@@ -1,4 +1,3 @@
-
 from os.path import *
 from pprint import pformat
 

--- a/perf/util.py
+++ b/perf/util.py
@@ -30,7 +30,7 @@ def timeit(func):
             return func(*args, **kw)
         finally:
             total_time = clock() - start_time
-            print("%s took %.3fs" % (func.__name__, total_time))
+            print("{} took {:.3f}s".format(func.__name__, total_time))
     return wrapper
 
 def hotshotit(func):

--- a/sandbox/wiki.py
+++ b/sandbox/wiki.py
@@ -1,4 +1,3 @@
-
 import sys
 import re
 from os.path import *

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ Intended Audience :: Developers
 License :: OSI Approved :: MIT License
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
@@ -57,7 +56,7 @@ setup(
         ]
     },
     description="A fast and complete Python implementation of Markdown",
-    python_requires=">=3.8, <4",
+    python_requires=">=3.9, <4",
     extras_require=extras_require,
     classifiers=classifiers.strip().split("\n"),
     long_description="""markdown2: A fast and complete Python implementation of Markdown.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ Topic :: Text Processing :: Markup :: HTML
 
 extras_require = {
     "code_syntax_highlighting": ["pygments>=2.7.3"],
-    "wavedrom": ["wavedrom; python_version>='3.7'"],
+    "wavedrom": ["wavedrom"],
     "latex": ['latex2mathml; python_version>="3.8.1"'],
 }
 # nested listcomp to combine all optional extras into convenient "all" option

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
 Programming Language :: Python :: 3.12
+Programming Language :: Python :: 3.13
 Operating System :: OS Independent
 Topic :: Software Development :: Libraries :: Python Modules
 Topic :: Software Development :: Documentation

--- a/test/markdown.py
+++ b/test/markdown.py
@@ -116,7 +116,7 @@ ENTITY_NORMALIZATION_EXPRESSIONS = [ (re.compile("&"), "&amp;"),
                                      (re.compile(">"), "&gt;"),
                                      (re.compile("\""), "&quot;")]
 
-ENTITY_NORMALIZATION_EXPRESSIONS_SOFT = [ (re.compile("&(?!\#)"), "&amp;"),
+ENTITY_NORMALIZATION_EXPRESSIONS_SOFT = [ (re.compile(r"&(?!\#)"), "&amp;"),
                                      (re.compile("<"), "&lt;"),
                                      (re.compile(">"), "&gt;"),
                                      (re.compile("\""), "&quot;")]
@@ -325,7 +325,7 @@ class Element :
             value = self.attribute_values[attr]
             value = self.doc.normalizeEntities(value,
                                                avoidDoubleNormalizing=True)
-            buffer += ' %s="%s"' % (attr, value)
+            buffer += ' {}="{}"'.format(attr, value)
 
 
         # Now let's actually append the children
@@ -672,7 +672,7 @@ LINK_RE = BRK + r'\s*\(([^\)]*)\)'               # [text](url)
 LINK_ANGLED_RE = BRK + r'\s*\(<([^\)]*)>\)'      # [text](<url>)
 IMAGE_LINK_RE = r'\!' + BRK + r'\s*\(([^\)]*)\)' # ![alttxt](http://x.com/)
 REFERENCE_RE = BRK+ r'\s*\[([^\]]*)\]'           # [Google][3]
-IMAGE_REFERENCE_RE = r'\!' + BRK + '\s*\[([^\]]*)\]' # ![alt text][2]
+IMAGE_REFERENCE_RE = r'\!' + BRK + r'\s*\[([^\]]*)\]' # ![alt text][2]
 NOT_STRONG_RE = r'( \* )'                        # stand-alone * or _
 AUTOLINK_RE = r'<(http://[^>]*)>'                # <http://www.123.com>
 AUTOMAIL_RE = r'<([^> \!]*@[^> ]*)>'               # <me@example.com>

--- a/test/test.py
+++ b/test/test.py
@@ -27,10 +27,7 @@ def setup():
         import pygments  # noqa
     except ImportError:
         pygments_dir = join(top_dir, "deps", "pygments")
-        if sys.version_info[0] <= 2:
-            sys.path.insert(0, pygments_dir)
-        else:
-            sys.path.insert(0, pygments_dir + "3")
+        sys.path.insert(0, pygments_dir + "3")
 
 if __name__ == "__main__":
     logging.basicConfig()

--- a/test/test.py
+++ b/test/test.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         try:
             mod = importlib.import_module(extra_lib)
         except ImportError:
-            warnings.append("skipping %s tests ('%s' module not found)" % (extra_lib, extra_lib))
+            warnings.append("skipping {} tests ('{}' module not found)".format(extra_lib, extra_lib))
             default_tags.append("-%s" % extra_lib)
         else:
             if extra_lib == 'pygments':
@@ -48,7 +48,7 @@ if __name__ == "__main__":
                     tag = "pygments<2.14"
                 else:
                     tag = "pygments>=2.14"
-                warnings.append("skipping %s tests (pygments %s found)" % (tag, mod.__version__))
+                warnings.append("skipping {} tests (pygments {} found)".format(tag, mod.__version__))
                 default_tags.append("-%s" % tag)
 
     retval = testlib.harness(testdir_from_ns=testdir_from_ns,

--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -152,7 +152,7 @@ class _MarkdownTestCase(unittest.TestCase):
             if exists(opts_path):
                 try:
                     with warnings.catch_warnings(record=True) as caught_warnings:
-                        opts = eval(open(opts_path, 'r').read())
+                        opts = eval(open(opts_path).read())
                     for warning in caught_warnings:
                         print("WARNING: loading %s generated warning: %s - lineno %d" % (opts_path, warning.message, warning.lineno), file=sys.stderr)
                 except Exception:
@@ -335,7 +335,7 @@ def _markdown_email_link_sub(match):
     href, text = match.groups()
     href = _xml_escape_re.sub(_xml_escape_sub, href)
     text = _xml_escape_re.sub(_xml_escape_sub, text)
-    return '<a href="%s">%s</a>' % (href, text)
+    return '<a href="{}">{}</a>'.format(href, text)
 
 def norm_html_from_html(html):
     """Normalize (somewhat) Markdown'd HTML.

--- a/test/testall.py
+++ b/test/testall.py
@@ -53,14 +53,14 @@ def testall():
             # Don't support Python < 3.5
             continue
         ver_str = "%s.%s" % ver
-        print("-- test with Python %s (%s)" % (ver_str, python))
+        print("-- test with Python {} ({})".format(ver_str, python))
         assert ' ' not in python
 
         env_args = 'MACOSX_DEPLOYMENT_TARGET= ' if sys.platform == 'darwin' else ''
 
         proc = subprocess.Popen(
             # pass "-u" option to force unbuffered output
-            "%s%s -u test.py -- -knownfailure" % (env_args, python),
+            "{}{} -u test.py -- -knownfailure".format(env_args, python),
             shell=True, stderr=subprocess.PIPE
         )
 
@@ -77,6 +77,6 @@ def testall():
 
     for python, ver_str, warning in all_warnings:
         # now re-print all warnings to make sure they are seen
-        print('-- warning raised by Python %s (%s) -- %s' % (ver_str, python, warning))
+        print('-- warning raised by Python {} ({}) -- {}'.format(ver_str, python, warning))
 
 testall()

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -130,8 +130,8 @@ def timedtest(max_time, tolerance=TOLERANCE):
             finally:
                 total_time = time.time() - start_time
                 if total_time > max_time + tolerance:
-                    raise DurationError(('Test was too long (%.2f s)'
-                                           % total_time))
+                    raise DurationError('Test was too long (%.2f s)'
+                                           % total_time)
         return wrapper
 
     return _timedtest
@@ -140,7 +140,7 @@ def timedtest(max_time, tolerance=TOLERANCE):
 
 #---- module api
 
-class Test(object):
+class Test:
     def __init__(self, ns, testmod, testcase, testfn_name,
                  testsuite_class=None):
         self.ns = ns
@@ -439,7 +439,7 @@ def list_tests(testdir_from_ns, tags):
             if testfile.endswith(".pyc"):
                 testfile = testfile[:-1]
             print("%s:" % t.shortname())
-            print("  from: %s#%s.%s" % (testfile,
+            print("  from: {}#{}.{}".format(testfile,
                 t.testcase.__class__.__name__, t.testfn_name))
             wrapped = textwrap.fill(' '.join(t.tags()), WIDTH-10)
             print("  tags: %s" % _indent(wrapped, 8, True))
@@ -470,7 +470,7 @@ class ConsoleTestResult(unittest.TestResult):
 
     def getDescription(self, test):
         if test._testlib_explicit_tags_:
-            return "%s [%s]" % (test._testlib_shortname_,
+            return "{} [{}]".format(test._testlib_shortname_,
                                 ', '.join(test._testlib_explicit_tags_))
         else:
             return test._testlib_shortname_
@@ -514,7 +514,7 @@ class ConsoleTestResult(unittest.TestResult):
             self.stream.write("%s\n" % err)
 
 
-class ConsoleTestRunner(object):
+class ConsoleTestRunner:
     """A test runner class that displays results on the console.
 
     It prints out the names of tests as they are run, errors as they

--- a/tools/cutarelease.py
+++ b/tools/cutarelease.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (c) 2009-2012 Trent Mick
 
 """cutarelease -- Cut a release of your project.
@@ -154,10 +153,10 @@ def cutarelease(project_name, version_files, dry_run=False):
             % (changes_path, version))
 
     # Tag version and push.
-    curr_tags = set(t for t in _capture_stdout(["git", "tag", "-l"]).split(b'\n') if t)
+    curr_tags = {t for t in _capture_stdout(["git", "tag", "-l"]).split(b'\n') if t}
     if not dry_run and version not in curr_tags:
         log.info("tag the release")
-        run('git tag -a "%s" -m "version %s"' % (version, version))
+        run('git tag -a "{}" -m "version {}"'.format(version, version))
         run('git push --tags')
 
     # Optionally release.
@@ -193,9 +192,9 @@ def cutarelease(project_name, version_files, dry_run=False):
     if marker not in changes_txt:
         raise Error("couldn't find `%s' marker in `%s' "
             "content: can't prep for subsequent dev" % (marker, changes_path))
-    next_verline = "%s %s%s" % (marker.rsplit(None, 1)[0], next_version, nyr)
+    next_verline = "{} {}{}".format(marker.rsplit(None, 1)[0], next_version, nyr)
     changes_txt = changes_txt.replace(marker + '\n',
-        "%s\n\n(nothing yet)\n\n\n%s\n" % (next_verline, marker))
+        "{}\n\n(nothing yet)\n\n\n{}\n".format(next_verline, marker))
     if not dry_run:
         f = codecs.open(changes_path, 'w', 'utf-8')
         f.write(changes_txt)
@@ -221,12 +220,12 @@ def cutarelease(project_name, version_files, dry_run=False):
             ver_content = ver_content.replace(marker,
                 'var VERSION = "%s";' % next_version)
         elif ver_file_type == "python":
-            marker = "__version_info__ = %r" % (version_info,)
+            marker = "__version_info__ = {!r}".format(version_info)
             if marker not in ver_content:
                 raise Error("couldn't find `%s' version marker in `%s' "
                     "content: can't prep for subsequent dev" % (marker, ver_file))
             ver_content = ver_content.replace(marker,
-                "__version_info__ = %r" % (next_version_tuple,))
+                "__version_info__ = {!r}".format(next_version_tuple))
         elif ver_file_type == "version":
             ver_content = next_version
         else:
@@ -238,7 +237,7 @@ def cutarelease(project_name, version_files, dry_run=False):
             f.close()
 
     if not dry_run:
-        run('git commit %s %s -m "prep for future dev"' % (
+        run('git commit {} {} -m "prep for future dev"'.format(
             changes_path, ' '.join(version_files)))
         run('git push')
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{38, 39, 310, 311, 312, 313, py}
+envlist = py{39, 310, 311, 312, 313, py}
 
 [testenv]
 commands = make testone

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38, py39, py310, py311, py312, pypy
+envlist = py{38, 39, 310, 311, 312, 313, py}
 
 [testenv]
 commands = make testone

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,5 @@
 envlist = py{39, 310, 311, 312, 313, py}
 
 [testenv]
+allowlist_externals = make
 commands = make testone


### PR DESCRIPTION
* Add support for Python 3.13: https://discuss.python.org/t/python-3-13-0-final-has-been-released/66972/1
* Drop support for EOL Python 3.8: https://discuss.python.org/t/python-3-8-is-now-officially-eol/66983/1
* Upgrade syntax with pyupgrade `--py39-plus`
* Remove universal wheels, only needed when supporting both Python 2 and 3
* Remove redundant version checks
* Fix tox: 'failed with make is not allowed, use allowlist_externals to allow it'
