### PR TITLE
Fix `middle-word-em` extra preventing strongs from being recognized (#606)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## python-markdown2 2.5.2 (not yet released)
 
 - [pull #605] Add support for Python 3.13, drop EOL 3.8
+- [pull #607] Fix `middle-word-em` extra preventing strongs from being recognized (#606)
 
 
 ## python-markdown2 2.5.1

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -3144,7 +3144,20 @@ class MiddleWordEm(ItalicAndBoldProcessor):
 
         self.liberal_em_re = self.em_re
         if not options['allowed']:
-            self.em_re = re.compile(r'(?<=\b)%s(?=\b)' % self.liberal_em_re.pattern, self.liberal_em_re.flags)
+            self.em_re = re.compile(r'(?<=\b)%s(?=\b)' % self.em_re.pattern, self.em_re.flags)
+            self.liberal_em_re = re.compile(
+                r'''
+                    (                # \1 - must be a single em char in the middle of a word
+                        (?<![*_\s])  # cannot be preceeded by em character or whitespace (must be in middle of word)
+                        [*_]         # em character
+                        (?![*_])     # cannot be followed by another em char
+                    )
+                    (?=\S)           # em opening must be followed by non-whitespace text
+                    (.*?\S)          # the emphasized text
+                    \1               # closing char
+                    (?!\s|$)         # must not be followed by whitespace (middle of word) or EOF
+                '''
+                , re.S | re.X)
 
     def run(self, text):
         # run strong and whatnot first

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -3160,6 +3160,10 @@ class MiddleWordEm(ItalicAndBoldProcessor):
                 , re.S | re.X)
 
     def run(self, text):
+        if self.options['allowed']:
+            # if middle word em is allowed, do nothing. This extra's only use is to prevent them
+            return text
+
         # run strong and whatnot first
         # this also will process all strict ems
         text = super().run(text)

--- a/test/tm-cases/middle_word_em_with_extra_ems.html
+++ b/test/tm-cases/middle_word_em_with_extra_ems.html
@@ -1,0 +1,19 @@
+<p>Double variants:</p>
+
+<p><strong>one_two_three</strong></p>
+
+<p><strong><em>one_two_three</em></strong></p>
+
+<p><em><strong>one_two_three</strong></em></p>
+
+<p><strong><em>one_two_three</em></strong></p>
+
+<p>Single variants:</p>
+
+<p><em>one_two_three</em></p>
+
+<p><em>one_two_three</em></p>
+
+<p><em>one*two*three</em></p>
+
+<p><em>one<em>two</em>three</em></p>

--- a/test/tm-cases/middle_word_em_with_extra_ems.opts
+++ b/test/tm-cases/middle_word_em_with_extra_ems.opts
@@ -1,0 +1,1 @@
+{"extras": {"middle-word-em": False}}

--- a/test/tm-cases/middle_word_em_with_extra_ems.text
+++ b/test/tm-cases/middle_word_em_with_extra_ems.text
@@ -1,0 +1,19 @@
+Double variants:
+
+**one_two_three**
+
+***one_two_three***
+
+_**one_two_three**_
+
+**_one_two_three_**
+
+Single variants:
+
+*one_two_three*
+
+_one_two_three_
+
+_one*two*three_
+
+*one*two*three*


### PR DESCRIPTION
This PR fixes #606 by altering the regex used in `middle-word-em` so that it doesn't match against intentional emphasis markers.

Previously, a snippet such as `**one_two_three**` would have been matched aside from the last character. This is due to the old regex matching emphasis markers without any regard for whether they are `em` (single) or `strong` (double).

The new regex will only match markers that aren't preceded or followed by a similar marker