### PR TITLE
Add option to output to file in CLI (#608)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - [pull #605] Add support for Python 3.13, drop EOL 3.8
 - [pull #607] Fix `middle-word-em` extra preventing strongs from being recognized (#606)
+- [pull #609] Add option to output to file in CLI (#608)
 
 
 ## python-markdown2 2.5.1

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -3985,6 +3985,7 @@ def main(argv=None):
                       help="run internal self-tests (some doctests)")
     parser.add_argument("--compare", action="store_true",
                       help="run against Markdown.pl as well (for testing)")
+    parser.add_argument('--output', type=str, help='output to a file instead of stdout')
     parser.set_defaults(log_level=logging.INFO, compare=False,
                         encoding="utf-8", safe_mode=None, use_file_vars=False)
     opts = parser.parse_args()
@@ -4059,7 +4060,11 @@ def main(argv=None):
             extras=extras, link_patterns=link_patterns,
             use_file_vars=opts.use_file_vars,
             cli=True)
-        sys.stdout.write(html)
+        if opts.output:
+            with open(opts.output, 'w') as f:
+                f.write(html)
+        else:
+            sys.stdout.write(html)
         if extras and "toc" in extras:
             log.debug("toc_html: " +
                 str(html.toc_html.encode(sys.stdout.encoding or "utf-8", 'xmlcharrefreplace')))


### PR DESCRIPTION
This PR closes #608 by adding a CLI option to output to a file instead of stdout. Example usage:
```bash
python lib/markdown2.py text.md --output index.html
```