### PR TITLE
Fix footnote labels appearing out-of-order (#536)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - [pull #605] Add support for Python 3.13, drop EOL 3.8
 - [pull #607] Fix `middle-word-em` extra preventing strongs from being recognized (#606)
 - [pull #609] Add option to output to file in CLI (#608)
+- [pull #612] Fix footnote labels appearing out-of-order (#536)
 
 
 ## python-markdown2 2.5.1

--- a/test/tm-cases/footnotes_order_of_appearance.html
+++ b/test/tm-cases/footnotes_order_of_appearance.html
@@ -2,12 +2,12 @@
 
 <h2>title: testing the footnotes bug</h2>
 
-<p>Lorem ipsum dolor sit amet. Aliqua cillum, eu velit.<sup class="footnote-ref" id="fnref-note1"><a href="#fn-note1">3</a></sup> Velit deserunt adipiscing adipiscing ullamco exercitation.</p>
+<p>Lorem ipsum dolor sit amet. Aliqua cillum, eu velit.<sup class="footnote-ref" id="fnref-note1"><a href="#fn-note1">1</a></sup> Velit deserunt adipiscing adipiscing ullamco exercitation.</p>
 
 <ul>
 <li>this is a list item</li>
-<li>this is a list item<sup class="footnote-ref" id="fnref-note2"><a href="#fn-note2">1</a></sup></li>
-<li>this is a list item<sup class="footnote-ref" id="fnref-note3"><a href="#fn-note3">2</a></sup></li>
+<li>this is a list item<sup class="footnote-ref" id="fnref-note2"><a href="#fn-note2">2</a></sup></li>
+<li>this is a list item<sup class="footnote-ref" id="fnref-note3"><a href="#fn-note3">3</a></sup></li>
 </ul>
 
 <p>Lorem ipsum dolor sit amet. Adipiscing<sup class="footnote-ref" id="fnref-note4"><a href="#fn-note4">4</a></sup> adipiscing ullamco, exercitation sint. Exercitation sint, fugiat exercitation voluptate amet.</p>


### PR DESCRIPTION
This PR follows up on a comment on #536 that shows that the footnote labels are appearing out-of-order, even though the footnote links themselves are accurate. This bug was due to the out-of-order processing of some markdown elements and the order of insertion into the `footnote_ids` list.

Example:

```
one [^1]

- two [^2]


[^1]: one
[^2]: two
```

The footnote label is inserted [as each footnote is processed](https://github.com/trentm/python-markdown2/blob/c2b74275ca3e9d839cf627f4e160396d6ea9fc88/lib/markdown2.py#L1587). However, the list is processed first, which means its footnote is processed firstthat it is given the label of `1` mistakenly.

This PR fixes that by instead inserting a placeholder here, and then postprocessing the entire text top-to-bottom, which fixes the labelling.