### PR TITLE
Add `MarkdownFileLinks` extra (#528)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## python-markdown2 2.5.4 (not yet released)
 
-(nothing yet)
+- [pull #617] Add MarkdownFileLinks extra (#528)
 
 
 ## python-markdown2 2.5.3

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -3271,10 +3271,14 @@ class MarkdownFileLinks(LinkProcessor):
         options = {'tags': ['a'], 'ref': False, **(options or {})}
         super().__init__(md, options)
 
-    def process_anchor(self, url: str, title_attr: str, link_text: str):
-        if url.endswith('.md'):
-            url = url.removesuffix('.md') + '.html'
-        return super().process_anchor(url, title_attr, link_text)
+    def parse_inline_anchor_or_image(self, text: str, _link_text: str, start_idx: int):
+        result = super().parse_inline_anchor_or_image(text, _link_text, start_idx)
+        if not result or not result[1] or not result[1].endswith('.md'):
+            # return None for invalid markup, or links that don't end with '.md'
+            # so that we don't touch them, and other extras can process them freely
+            return
+        url = result[1].removesuffix('.md') + '.html'
+        return result[0], url, *result[2:]
 
     def run(self, text: str):
         if Stage.LINKS > self.md.order > Stage.LINK_DEFS and self.options.get('link_defs', True):

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2509,7 +2509,7 @@ class LinkProcessor(Extra):
     order = (Stage.ITALIC_AND_BOLD,), (Stage.ESCAPE_SPECIAL,)
     options: _LinkProcessorExtraOpts
 
-    def __init__(self, md: Markdown, options: Dict | None):
+    def __init__(self, md: Markdown, options: Optional[dict]):
         options = options or {}
         super().__init__(md, options)
 
@@ -3247,7 +3247,7 @@ class MarkdownFileLinks(LinkProcessor):
     order = (Stage.LINKS,), (Stage.LINK_DEFS,)
     options: _MarkdownFileLinksExtraOpts
 
-    def __init__(self, md: Markdown, options: Dict | None):
+    def __init__(self, md: Markdown, options: Optional[dict]):
         # override LinkProcessor defaults
         options = {'tags': ['a'], 'ref': False, **(options or {})}
         super().__init__(md, options)

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1447,25 +1447,6 @@ class Markdown:
             i += 1
         return i
 
-    def _extract_url_and_title(self, text: str, start: int) -> Union[tuple[str, str, int], tuple[None, None, None]]:
-        """Extracts the url and (optional) title from the tail of a link"""
-        # text[start] equals the opening parenthesis
-        idx = self._find_non_whitespace(text, start+1)
-        if idx == len(text):
-            return None, None, None
-        end_idx = idx
-        has_anglebrackets = text[idx] == "<"
-        if has_anglebrackets:
-            end_idx = self._find_balanced(text, end_idx+1, "<", ">")
-        end_idx = self._find_balanced(text, end_idx, "(", ")")
-        match = self._inline_link_title.search(text, idx, end_idx)
-        if not match:
-            return None, None, None
-        url, title = text[idx:match.start()], match.group("title")
-        if has_anglebrackets:
-            url = self._strip_anglebrackets.sub(r'\1', url)
-        return url, title, end_idx
-
     # https://developer.mozilla.org/en-US/docs/web/http/basics_of_http/data_urls
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
     _data_url_re = re.compile(r'''

--- a/test/testall.py
+++ b/test/testall.py
@@ -17,7 +17,7 @@ def _python_ver_from_python(python):
     assert ' ' not in python
     o = os.popen('''%s -c "import sys; print(sys.version)"''' % python)
     ver_str = o.read().strip()
-    ver_bits = re.split(r"\.|[^\d]", ver_str, 2)[:2]
+    ver_bits = re.split(r"\.|[^\d]", ver_str, maxsplit=2)[:2]
     ver = tuple(map(int, ver_bits))
     return ver
 

--- a/test/tm-cases/fenced_code_blocks_issue426.html
+++ b/test/tm-cases/fenced_code_blocks_issue426.html
@@ -15,7 +15,7 @@
 <li><p><code>ContextMixin</code> defines the method <code>get_context_data</code>:</p>
 
 <div class="codehilite">
-<pre><span></span><code><span class="k">def</span> <span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+<pre><span></span><code><span class="k">def</span><span class="w"> </span><span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
     <span class="n">kwargs</span><span class="o">.</span><span class="n">setdefault</span><span class="p">(</span><span class="s1">&#39;view&#39;</span><span class="p">,</span> <span class="bp">self</span><span class="p">)</span>
     <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">extra_context</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
         <span class="n">kwargs</span><span class="o">.</span><span class="n">update</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">extra_context</span><span class="p">)</span>
@@ -26,7 +26,7 @@
 <p>So when overriding one must be careful to extends <code>super</code>'s <code>kwargs</code>:</p>
 
 <div class="codehilite">
-<pre><span></span><code><span class="k">def</span> <span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+<pre><span></span><code><span class="k">def</span><span class="w"> </span><span class="nf">get_context_data</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
     <span class="n">kwargs</span> <span class="o">=</span> <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="n">get_context_data</span><span class="p">(</span><span class="o">**</span><span class="n">kwargs</span><span class="p">)</span>
     <span class="n">kwargs</span><span class="p">[</span><span class="s1">&#39;page_title&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s2">&quot;Documentation&quot;</span>
     <span class="k">return</span> <span class="n">kwargs</span>

--- a/test/tm-cases/fenced_code_blocks_syntax_indentation.html
+++ b/test/tm-cases/fenced_code_blocks_syntax_indentation.html
@@ -1,5 +1,5 @@
 <div class="codehilite">
-<pre><span></span><code><span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>
+<pre><span></span><code><span class="k">def</span><span class="w"> </span><span class="nf">foo</span><span class="p">():</span>
     <span class="nb">print</span> <span class="s2">&quot;foo&quot;</span>
 
     <span class="nb">print</span> <span class="s2">&quot;bar&quot;</span>

--- a/test/tm-cases/markdown_file_links.html
+++ b/test/tm-cases/markdown_file_links.html
@@ -1,0 +1,3 @@
+<p><a href="./file.html">This is a link to a markdown file</a></p>
+
+<p><a href="./something.html">This is a reference to a markdown file link</a></p>

--- a/test/tm-cases/markdown_file_links.opts
+++ b/test/tm-cases/markdown_file_links.opts
@@ -1,0 +1,1 @@
+{'extras': ['markdown-file-links']}

--- a/test/tm-cases/markdown_file_links.text
+++ b/test/tm-cases/markdown_file_links.text
@@ -1,0 +1,6 @@
+[This is a link to a markdown file](./file.md)
+
+[This is a reference to a markdown file link][]
+
+
+[This is a reference to a markdown file link]: ./something.md

--- a/test/tm-cases/markdown_file_links_no_linkdefs.html
+++ b/test/tm-cases/markdown_file_links_no_linkdefs.html
@@ -1,0 +1,1 @@
+<p><a href="./something.md">This is a reference to a markdown file link</a> but link definition swapping is disabled</p>

--- a/test/tm-cases/markdown_file_links_no_linkdefs.opts
+++ b/test/tm-cases/markdown_file_links_no_linkdefs.opts
@@ -1,0 +1,1 @@
+{'extras': {'markdown-file-links': {'link_defs': False}}}

--- a/test/tm-cases/markdown_file_links_no_linkdefs.text
+++ b/test/tm-cases/markdown_file_links_no_linkdefs.text
@@ -1,0 +1,4 @@
+[This is a reference to a markdown file link][] but link definition swapping is disabled
+
+
+[This is a reference to a markdown file link]: ./something.md


### PR DESCRIPTION
This PR closes #528 by adding an extra that converts `.md` links to `.html` links. I've also spun the link processing logic out into a `LinkProcessor` extra, which can be subclassed and re-used just like the `ItalicAndBoldProcessor`.

### LinkProcessor

This new extra contains all of the link processing logic, allowing new extras to piggy-back off of it and manipulate links without having to re-implement the syntax matching themselves.

The class allows subclasses to filter which links they wish to process (inline/reference and anchor/image).

### MarkdownFileLinks

Simply replaces `.md` links with `.html`. Also works for link definitions, although this can be turned off using the extra's options. EG: `markdown(..., extras={'markdown-file-links': {'link_defs': False}})`