### PR TITLE
Add missing block tags to regex (#620)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## python-markdown2 2.5.4 (not yet released)
 
 - [pull #617] Add MarkdownFileLinks extra (#528)
+- [pull #622] Add missing block tags to regex (#620)
 
 
 ## python-markdown2 2.5.3

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -859,9 +859,9 @@ class Markdown:
 
     # I broke out the html5 tags here and add them to _block_tags_a and
     # _block_tags_b.  This way html5 tags are easy to keep track of.
-    _html5tags = '|article|aside|header|hgroup|footer|nav|section|figure|figcaption'
+    _html5tags = '|address|article|aside|canvas|figcaption|figure|footer|header|main|nav|section|video'
 
-    _block_tags_a = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del|style|html|head|body'
+    _block_tags_a = 'blockquote|body|dd|del|div|dl|dt|fieldset|form|h[1-6]|head|hr|html|iframe|ins|li|math|noscript|ol|p|pre|script|style|table|tfoot|ul'
     _block_tags_a += _html5tags
 
     _strict_tag_block_re = re.compile(r"""
@@ -877,7 +877,7 @@ class Markdown:
         """ % _block_tags_a,
         re.X | re.M)
 
-    _block_tags_b = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math'
+    _block_tags_b = 'blockquote|div|dl|fieldset|form|h[1-6]|iframe|math|noscript|ol|p|pre|script|table|ul'
     _block_tags_b += _html5tags
 
     _span_tags = (

--- a/test/tm-cases/smarty_pants_issue620.html
+++ b/test/tm-cases/smarty_pants_issue620.html
@@ -1,0 +1,15 @@
+<p>Some HTML5 block level elements that should be hashed so that smarty-pants doesn&#8217;t interfere</p>
+
+<address>
+  <a href="mailto:jim@example.com">jim@example.com</a><br />
+  <a href="tel:+14155550132">+1 (415) 555‑0132</a>
+</address>
+
+<canvas width="120" height="120">
+  An alternative text describing what your canvas displays.
+</canvas>
+
+<video height="640" width="382" controls loop>
+    <source src="images/door.mp4"  type="video/mp4"/>
+    Test
+</video>

--- a/test/tm-cases/smarty_pants_issue620.opts
+++ b/test/tm-cases/smarty_pants_issue620.opts
@@ -1,0 +1,1 @@
+{"extras": ["smarty-pants"]}

--- a/test/tm-cases/smarty_pants_issue620.text
+++ b/test/tm-cases/smarty_pants_issue620.text
@@ -1,0 +1,15 @@
+Some HTML5 block level elements that should be hashed so that smarty-pants doesn't interfere
+
+<address>
+  <a href="mailto:jim@example.com">jim@example.com</a><br />
+  <a href="tel:+14155550132">+1 (415) 555‑0132</a>
+</address>
+
+<canvas width="120" height="120">
+  An alternative text describing what your canvas displays.
+</canvas>
+
+<video height="640" width="382" controls loop>
+    <source src="images/door.mp4"  type="video/mp4"/>
+    Test
+</video>


### PR DESCRIPTION
This PR fixes #620 by adding missing block tags to the block tags regex.

Smarty-pants was mangling quotes in the `video` element, which should be hashed by `_hash_html_blocks`, but `video` was missing from `_html5tags` and `_block_tags_a`. Adding it fixed this.

I also added a bunch of other block-level tags listed on [w3docs](https://www.w3docs.com/learn-html/html-block-and-inline-elements.html) such as `canvas`, `dd`, `dt` and `address`