### PR TITLE
Don't escape plus signs in URLs (#621)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## python-markdown2 2.5.4 (not yet released)
 
 - [pull #617] Add MarkdownFileLinks extra (#528)
-
+- [pull #623] Don't escape plus signs in URLs (#621)
 
 ## python-markdown2 2.5.3
 

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -4099,8 +4099,6 @@ def _html_escape_url(
         .replace('<', '&lt;')
         .replace('>', '&gt;'))
     if safe_mode:
-        if charset != 'base64':
-            escaped = escaped.replace('+', ' ')
         escaped = escaped.replace("'", "&#39;")
     return escaped
 

--- a/test/tm-cases/safe_mode_issue621.html
+++ b/test/tm-cases/safe_mode_issue621.html
@@ -1,0 +1,1 @@
+<p><a href="https://chromium.googlesource.com/v8/v8.git/+/refs/heads/beta">Chromium</a></p>

--- a/test/tm-cases/safe_mode_issue621.opts
+++ b/test/tm-cases/safe_mode_issue621.opts
@@ -1,0 +1,1 @@
+{'safe_mode': 'escape'}

--- a/test/tm-cases/safe_mode_issue621.text
+++ b/test/tm-cases/safe_mode_issue621.text
@@ -1,0 +1,1 @@
+[Chromium](https://chromium.googlesource.com/v8/v8.git/+/refs/heads/beta)


### PR DESCRIPTION
This PR fixes #621 by changing `_html_escape_url` to no longer escape `+` characters.

As pointed out in #621, `+` [is a valid URL character](https://stackoverflow.com/a/7109208), and therefore shouldn't be escaped in URLs.

I'm not sure exactly why they were being escaped in the first place, although it seems the first usage comes from 000343d as part of #230:
```python
if safe_mode:
    escaped = quote_plus(attr).replace('+', ' ')
```
[`quote_plus`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote_plus) replaces spaces with plus signs, and I'm guessing escapes some other characters too. They then go back and replace the plus signs with spaces again. Seems redundant and doesn't look like we need it
