### PR TITLE
Fix XSS when encoding incomplete tags (#625)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - [pull #617] Add MarkdownFileLinks extra (#528)
 - [pull #622] Add missing block tags to regex (#620)
 - [pull #623] Don't escape plus signs in URLs (#621)
+- [pull #626] Fix XSS when encoding incomplete tags (#625)
 
 
 ## python-markdown2 2.5.3

--- a/test/tm-cases/encode_incomplete_tags_xss_issue625.html
+++ b/test/tm-cases/encode_incomplete_tags_xss_issue625.html
@@ -1,0 +1,1 @@
+<p>&lt;x&gt;&lt;img src=x onerror=alert("xss")//>&lt;x&gt;</p>

--- a/test/tm-cases/encode_incomplete_tags_xss_issue625.opts
+++ b/test/tm-cases/encode_incomplete_tags_xss_issue625.opts
@@ -1,0 +1,1 @@
+{'safe_mode': 'escape'}

--- a/test/tm-cases/encode_incomplete_tags_xss_issue625.text
+++ b/test/tm-cases/encode_incomplete_tags_xss_issue625.text
@@ -1,0 +1,1 @@
+<x><img src=x onerror=alert("xss")//><x>


### PR DESCRIPTION
This PR fixes #625 by doing a proper and thorough check for auto links in `_encode_incomplete_tags`.

The previous check was flimsy and could easily be tricked by some malicious HTML.