### PR TITLE
Fix TypeError in MiddleWordEm extra when options was None (#627)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - [pull #622] Add missing block tags to regex (#620)
 - [pull #623] Don't escape plus signs in URLs (#621)
 - [pull #626] Fix XSS when encoding incomplete tags (#625)
+- [pull #628] Fix TypeError in MiddleWordEm extra when options was None (#627)
 
 
 ## python-markdown2 2.5.3

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2460,7 +2460,7 @@ class ItalicAndBoldProcessor(Extra):
     strong_re = Markdown._strong_re
     em_re = Markdown._em_re
 
-    def __init__(self, md: Markdown, options: dict):
+    def __init__(self, md: Markdown, options: Optional[dict]):
         super().__init__(md, options)
         self.hash_table = {}
 
@@ -3293,7 +3293,7 @@ class MiddleWordEm(ItalicAndBoldProcessor):
     name = 'middle-word-em'
     order = (CodeFriendly,), (Stage.ITALIC_AND_BOLD,)
 
-    def __init__(self, md: Markdown, options: Union[dict, bool]):
+    def __init__(self, md: Markdown, options: Union[dict, bool, None]):
         '''
         Args:
             md: the markdown instance
@@ -3304,6 +3304,8 @@ class MiddleWordEm(ItalicAndBoldProcessor):
         '''
         if isinstance(options, bool):
             options = {'allowed': options}
+        else:
+            options = options or {}
         options.setdefault('allowed', True)
         super().__init__(md, options)
 

--- a/test/tm-cases/middle_word_em_issue627.html
+++ b/test/tm-cases/middle_word_em_issue627.html
@@ -1,0 +1,1 @@
+<p>abc<em>def</em>ghi</p>

--- a/test/tm-cases/middle_word_em_issue627.opts
+++ b/test/tm-cases/middle_word_em_issue627.opts
@@ -1,0 +1,1 @@
+{'extras': {'middle-word-em': None}}

--- a/test/tm-cases/middle_word_em_issue627.text
+++ b/test/tm-cases/middle_word_em_issue627.text
@@ -1,0 +1,1 @@
+abc_def_ghi


### PR DESCRIPTION
This PR fixes #627, where if the extra options for `middle-word-em` was set to `None` it would raise a TypeError.

For extras, it's possible to initialise them without any options like so: `extras={'abc': None}`. This is usually handled in `Extra.__init__` and converted to an empty dictionary, so that the extras don't have to worry about a bunch of runtime type checks:

https://github.com/trentm/python-markdown2/blob/c91007d82f90f55800b69adc6298a75351e710af/lib/markdown2.py#L2382

However, middle-word-em would try to set some default options before calling `super().__init__`, and didn't have sufficient checks for if the value is None. This PR adds a check and converts it to a dict if so