### PR TITLE
Fix ReDoS in HTML tokenizer regex (#633)

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -27,3 +27,6 @@ jobs:
       - name: Test
         run: |
           make testone
+      - name: Test ReDoS
+        run: |
+          make testredos

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - [pull #626] Fix XSS when encoding incomplete tags (#625)
 - [pull #628] Fix TypeError in MiddleWordEm extra when options was None (#627)
 - [pull #630] Fix nbsp breaking tables (#629)
+- [pull #634] Fix ReDoS in HTML tokenizer regex (#633)
 
 
 ## python-markdown2 2.5.3

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ test:
 testone:
 	cd test && python test.py -- -knownfailure
 
+.PHONY: testredos
+testredos:
+	python test/test_redos.py
+
 .PHONY: pygments
 pygments:
 	[[ -d deps/pygments ]] || ( \

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1273,7 +1273,7 @@ class Markdown:
                     \s+                           # whitespace after tag
                     (?:[^\t<>"'=/]+:)?
                     [^<>"'=/]+=                   # attr name
-                    (?:".*?"|'.*?'|[^<>"'=/\s]+)  # value, quoted or unquoted. If unquoted, no spaces allowed
+                    (?:"[^"]*?"|'[^']*?'|[^<>"'=/\s]+)  # value, quoted or unquoted. If unquoted, no spaces allowed
                 )*
                 \s*/?>
                 |

--- a/test/test_redos.py
+++ b/test/test_redos.py
@@ -35,7 +35,7 @@ def issue493():
 
 def issue_633():
     # https://github.com/trentm/python-markdown2/issues/633
-    return '<p m="1"' * 5000 + " " * 10_000 + "</div"
+    return '<p m="1"' * 2500 + " " * 5000 + "</div"
 
 
 # whack everything in a dict for easy lookup later on

--- a/test/test_redos.py
+++ b/test/test_redos.py
@@ -1,0 +1,90 @@
+import logging
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+log = logging.getLogger("test")
+LIB_DIR = Path(__file__).parent.parent / "lib"
+
+
+def pull_387_example_1():
+    # https://github.com/trentm/python-markdown2/pull/387
+    return "[#a" + " " * 3456
+
+
+def pull_387_example_2():
+    # https://github.com/trentm/python-markdown2/pull/387
+    return "```" + "\n" * 3456
+
+
+def pull_387_example_3():
+    # https://github.com/trentm/python-markdown2/pull/387
+    return "-*-" + " " * 3456
+
+
+def pull_402():
+    # https://github.com/trentm/python-markdown2/pull/402
+    return " " * 100_000 + "$"
+
+
+def issue493():
+    # https://github.com/trentm/python-markdown2/issues/493
+    return "**_" + "*_" * 38730 * 10 + "\x00"
+
+
+def issue_633():
+    # https://github.com/trentm/python-markdown2/issues/633
+    return '<p m="1"' * 5000 + " " * 10_000 + "</div"
+
+
+# whack everything in a dict for easy lookup later on
+CASES = {
+    fn.__name__: fn
+    for fn in [
+        pull_387_example_1,
+        pull_387_example_2,
+        pull_387_example_3,
+        pull_402,
+        issue493,
+        issue_633,
+    ]
+}
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+
+    if "--execute" in sys.argv:
+        testcase = CASES[sys.argv[sys.argv.index("--execute") + 1]]
+        sys.path.insert(0, str(LIB_DIR))
+        from markdown2 import markdown
+
+        markdown(testcase())
+        sys.exit(0)
+
+    print("-- ReDoS tests")
+
+    fails = []
+    start_time = time.time()
+    for testcase in CASES:
+        print(f"markdown2/redos/{testcase} ... ", end="")
+
+        testcase_start_time = time.time()
+        try:
+            subprocess.run([sys.executable, __file__, "--execute", testcase], timeout=3)
+        except subprocess.TimeoutExpired:
+            fails.append(testcase)
+            print(f"FAIL ({time.time() - testcase_start_time:.3f}s)")
+        else:
+            print(f"ok ({time.time() - testcase_start_time:.3f}s)")
+
+    print("----------------------------------------------------------------------")
+    print(f"Ran {len(CASES)} tests in {time.time() - start_time:.3f}s")
+
+    if fails:
+        print("FAIL:", fails)
+    else:
+        print("OK")
+
+    sys.exit(len(fails))


### PR DESCRIPTION
This PR fixes #633, which showcases a ReDoS vulnerability in `_sorta_html_tokenize_re`. This PR also adds a regression test suite for ReDoS attacks and integrates it as part of the CICD checks.

## The fix

The problem was with the section of regex that matches tags with attributes, specifically line 1276:

https://github.com/trentm/python-markdown2/blob/adf4e8199ec08ee2ade22eb80703cfb44decbbce/lib/markdown2.py#L1272-L1278

The problem was with the section that matches quoted attribute values using `".*?"`. Take the following input:
```
<p m="1"<p m="1"<p m="1"<p m="1"<p m="1"<p m="1"<p m="1" ...[x 5000]...         </div
```
The first `m="1"` matches the attribute regex just fine, but then we hit another `<p` right after. The regex expects a closing bracket for this tag, so it assumes this is part of the attribute as well. It ends up consuming the whole string and matching `m="1"<p m="1"<p m="1" ...[x5000]...<p m="1"` as the attribute until it reaches the end of the input, at which point it fails to find a match and catastrophically backtracks.

By changing the attribute matching criteria to `"[^"]*?"`, we negate this. The regex reads `m="1"` as the attribute, `<p` then breaks the match immediately and the regex can exit.


This is what I believe happened, based on what I saw stepping through it with [debuggex](https://www.debuggex.com/r/oIoJsqLofFCrfNAF).

## The new test suite

Since alot of these redos attacks rely on creating a massive string to force extensive backtracking, I thought it would be inefficient to include them with the normal testcase files.

What I've done instead is added a separate test suite that will generate these inputs on the fly and pass it to the library. It uses a time limit to decide pass/fail, with no test case taking longer than 3s.

I searched the repo for any ReDoS related issues/PRs and added a test case for each of them.

I've added this to the makefile as `make testredos` and also added it to the CICD workflow.