### PR TITLE
compatibility with Pytest 8.4+

### DIFF
--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -555,12 +555,12 @@ def _one_line_summary_from_text(text, length=78,
 def test_cases():
     """This is called by test.py to build up the test cases."""
     TMTestCase.generate_tests()
-    yield TMTestCase
+    TMTestCase()
     MarkdownTestTestCase.generate_tests()
-    yield MarkdownTestTestCase
+    MarkdownTestTestCase()
     PHPMarkdownTestCase.generate_tests()
-    yield PHPMarkdownTestCase
+    PHPMarkdownTestCase()
     PHPMarkdownExtraTestCase.generate_tests()
-    yield PHPMarkdownExtraTestCase
-    yield DirectTestCase
-    yield DocTestsTestCase
+    PHPMarkdownExtraTestCase()
+    DirectTestCase()
+    DocTestsTestCase()


### PR DESCRIPTION
Hi,

This is tha patch applied in Debian for Pytest 8.4+ compatibility.

https://docs.pytest.org/en/stable/changelog.html#pytest-8-4-0-2025-06-02

[#12960](https://github.com/pytest-dev/pytest/issues/12960): Test functions containing a yield now cause an explicit error. They have not been run since pytest 4.0, and were previously marked as an expected failure and deprecation warning.