### PR TITLE
Fix middle-word-em interfering with strongs (#637)

### DIFF
--- a/test/tm-cases/middle_word_em_issue637.html
+++ b/test/tm-cases/middle_word_em_issue637.html
@@ -1,0 +1,2 @@
+<p>Visit <a href="https://github.com"><strong>GitHub</strong></a> for code repositories and
+<a href="https://stackoverflow.com"><strong>Stack Overflow</strong></a> for programming help.</p>

--- a/test/tm-cases/middle_word_em_issue637.opts
+++ b/test/tm-cases/middle_word_em_issue637.opts
@@ -1,0 +1,1 @@
+{'extras': {'middle-word-em': False}}

--- a/test/tm-cases/middle_word_em_issue637.text
+++ b/test/tm-cases/middle_word_em_issue637.text
@@ -1,0 +1,2 @@
+Visit [**GitHub**](https://github.com) for code repositories and
+[**Stack Overflow**](https://stackoverflow.com) for programming help.

--- a/test/tm-cases/middle_word_em_with_extra_ems.html
+++ b/test/tm-cases/middle_word_em_with_extra_ems.html
@@ -16,4 +16,4 @@
 
 <p><em>one*two*three</em></p>
 
-<p><em>one<em>two</em>three</em></p>
+<p><em>one*two*three</em></p>


### PR DESCRIPTION
This PR fixes #637.

The issue came down to the fact that the extra would run before the italics and bold stage. It would attempt to ignore the `<strong>` and then process strict `<em>`s and middle-word-ems. The problem is that the syntax for strongs and ems are very similar, and trying to craft a regex that can differentiate is tough.

The way this extra worked previously was to process valid `<em>` syntax and then hash anything that looks like `<em>` syntax but isn't quite valid.

The new approach is simply to find any `_` or `*` character in the middle of a word and hash it. This way, the regular italics and bold stage don't have to worry about them and we can keep the regexes simple.

The hash we use is basically the same that you find in `self._escape_table` except we prefix the extra's name to the input text to prevent interference with escaped/hashed chars from other stages