### PR TITLE
Fix code friendly preventing other syntax from being processed (#638)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## python-markdown2 2.5.5 (not yet released)
 
-(nothing yet)
+- [pull #640] Fix code friendly extra stopping other syntax being processed (#638)
 
 
 ## python-markdown2 2.5.4

--- a/test/tm-cases/code_friendly_issue638.html
+++ b/test/tm-cases/code_friendly_issue638.html
@@ -1,0 +1,1 @@
+<p>a_b this should be <strong>bold</strong> c_d this is <strong>bold</strong></p>

--- a/test/tm-cases/code_friendly_issue638.opts
+++ b/test/tm-cases/code_friendly_issue638.opts
@@ -1,0 +1,1 @@
+{"extras":["code-friendly"]}

--- a/test/tm-cases/code_friendly_issue638.text
+++ b/test/tm-cases/code_friendly_issue638.text
@@ -1,0 +1,1 @@
+a_b this should be **bold** c_d this is **bold**


### PR DESCRIPTION
This PR fixes #638.

The issue was in the following snippet:
```md
a_b this should be **bold** c_d this is **bold**
```

Code friendly would recognise the text in-between the 2 underscores as a potential `<em>`. It would hash that entire section to protect it from being turned into an `<em>`, but this also prevented the contents of that substring from being processed, including the `<strong>` in the middle.

This is fixed by simply hashing the `_` characters instead, leaving the contents available to be processed as normal.