### PR TITLE
Fix a number of em/strong issues (#641, #642, #643)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - [pull #639] Fix middle-word-em interfering with strongs (#637)
 - [pull #640] Fix code friendly extra stopping other syntax being processed (#638)
+- [pull #644] Fix a number of em/strong issues (#641, #642, #643)
 
 
 ## python-markdown2 2.5.4

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -3320,7 +3320,7 @@ class MiddleWordEm(ItalicAndBoldProcessor):
         self.middle_word_em_re = re.compile(
             r'''
             (?<!^)         # To be middle of a word, it cannot be at the start of the input
-            (?<![*_\s])    # cannot be preceeded by em character or whitespace (must be in middle of word)
+            (?<![*_\W])    # cannot be preceeded by em char or non word char (must be in middle of word)
             ([*_])         # em char
             (?=\S)         # must be followed by non-whitespace char
             (?![*_]|$|\W)  # cannot be followed by another em char, EOF or a non-word char

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1989,12 +1989,12 @@ class Markdown:
         return hashed
 
     _strong_re = re.compile(r'''
-        [*_]*            # ignore any leading em chars because we want to wrap `<strong>` as tightly around the text as possible
-                         # eg: `***abc***` -> `*<strong>abc</strong>*` instead of `<strong>*abc*</strong>`
-                         # Makes subsequent <em> processing easier
-        (\*\*|__)(?=\S)  # strong syntax - must be followed by a non whitespace char
-        (.+?)            # the strong text itself
-        (?<=\S)\1        # closing syntax - must be preceeded by non whitespace char
+        (?:_{1,}|\*{1,})?  # ignore any leading em chars because we want to wrap `<strong>` as tightly around the text as possible
+                           # eg: `***abc***` -> `*<strong>abc</strong>*` instead of `<strong>*abc*</strong>`
+                           # Makes subsequent <em> processing easier
+        (\*\*|__)(?=\S)    # strong syntax - must be followed by a non whitespace char
+        (.+?)              # the strong text itself
+        (?<=\S)\1          # closing syntax - must be preceeded by non whitespace char
         ''',
         re.S | re.X
     )

--- a/test/markdowntest-cases/Strong and em together.html
+++ b/test/markdowntest-cases/Strong and em together.html
@@ -1,7 +1,7 @@
-<p><strong><em>This is strong and em.</em></strong></p>
+<p><em><strong>This is strong and em.</strong></em></p>
 
-<p>So is <strong><em>this</em></strong> word.</p>
+<p>So is <em><strong>this</strong></em> word.</p>
 
-<p><strong><em>This is strong and em.</em></strong></p>
+<p><em><strong>This is strong and em.</strong></em></p>
 
-<p>So is <strong><em>this</em></strong> word.</p>
+<p>So is <em><strong>this</strong></em> word.</p>

--- a/test/tm-cases/consecutive_strong_and_em.html
+++ b/test/tm-cases/consecutive_strong_and_em.html
@@ -1,0 +1,1 @@
+<p><strong>strong</strong><em>em</em><strong>strong</strong></p>

--- a/test/tm-cases/consecutive_strong_and_em.text
+++ b/test/tm-cases/consecutive_strong_and_em.text
@@ -1,0 +1,1 @@
+**strong***em***strong**

--- a/test/tm-cases/ems_across_spans.html
+++ b/test/tm-cases/ems_across_spans.html
@@ -1,0 +1,1 @@
+<p><strong>_confusing</strong> ident is <strong>_confusing</strong></p>

--- a/test/tm-cases/ems_across_spans.text
+++ b/test/tm-cases/ems_across_spans.text
@@ -1,0 +1,1 @@
+**_confusing** ident is **_confusing**

--- a/test/tm-cases/middle_word_em_issue641.html
+++ b/test/tm-cases/middle_word_em_issue641.html
@@ -1,0 +1,3 @@
+<p><strong>Strong</strong> (<em>em</em>)</p>
+
+<p>note:<em>this is good</em>, but <em>this is not</em></p>

--- a/test/tm-cases/middle_word_em_issue641.opts
+++ b/test/tm-cases/middle_word_em_issue641.opts
@@ -1,0 +1,1 @@
+{'extras': {'middle-word-em': False}}

--- a/test/tm-cases/middle_word_em_issue641.text
+++ b/test/tm-cases/middle_word_em_issue641.text
@@ -1,0 +1,3 @@
+**Strong** (*em*)
+
+note:*this is good*, but *this is not*

--- a/test/tm-cases/middle_word_em_with_extra_ems.html
+++ b/test/tm-cases/middle_word_em_with_extra_ems.html
@@ -2,7 +2,7 @@
 
 <p><strong>one_two_three</strong></p>
 
-<p><strong><em>one_two_three</em></strong></p>
+<p><em><strong>one_two_three</strong></em></p>
 
 <p><em><strong>one_two_three</strong></em></p>
 


### PR DESCRIPTION
This PR fixes #641, fixes #642 and fixes #643.

I put all these fixes in the same PR because I wanted to make sure they were compatible with each other, but that does mean it's a bit messy.

### Middle word em breaking `(*em*)` (#641)

The middle word em regex would check for `*_` chars that aren't preceded by another em char or a whitespace. The text `(*em*)` matches that, as the leading em char is not preceded by a space. It would then prevent this text from being processed as a valid em.
I've updated the regex to look for ems that aren't preceded by non-word chars (instead of whitespace) and that fixed this issue.
The result is that we process this as expected:
```html
(<em>em</em>)
```

### Improve handling for leading underscores (#642)

In this issue we had what looked like an `<em>` span, but it was straddling two other `<strong>` spans:
```md
**_confusing** ident is **_confusing**
```
This is not a valid em. Spans can be nested but they shouldn't stay open after the parent span closes.

I added some additional logic in the italics and bold stage that will check to see if the matched strong/em has any nested spans and that those spans are balanced and closed. If not, the strong/em is deemed invalid.

The result is that we process the strongs here, but not the em:
```html
<p><strong>_confusing</strong> ident is <strong>_confusing</strong></p>
```

### Consecutive strong/em can overlap (#643)

The strong/em regexes were starting their matches early as possible, and including as much text in the span as possible. This lead to the following text being processed like so:

1. `**strong***em***strong**`
2. `<strong>strong*</strong>em<strong>*strong</strong>`
3. `<strong>strong<em></strong>em<strong></em>strong</strong>`

This renders fine in most browsers, but is invalid html.

To fix this, I modified the strong regex to try to ignore as many leading `*_` chars as possible to try to get the opening `<strong>` tag as close to the actual contents as possible, and try to close the `</strong>` as soon as possible.

Previously the strong regex would process `***abc***` as `<strong>*abc*</strong>` but now it will do `*<strong>abc</strong>`

The effect of this is when we have consecutive strong and ems, they won't overlap anymore.

The unfortunate side effect is Github will process `***abc**` as `<strong>*abc</strong>`, but we will output `*<strong>abc</strong>` instead, omitting that first em char from the span.