### PR TITLE
Fix empty links breaking backslash newlines (#648)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -1464,6 +1464,10 @@ class Markdown:
         and then hashes the now "safe" URL to prevent other safety mechanisms from tampering
         with it (eg: escaping "&" in URL parameters)
         '''
+        if not url:
+            # ignore links with empty URLs. Don't bother putting a hash there because then we'll have
+            # `"''"": "md5-..."` as an entry in the escape table, and that will cause havok
+            return url
         data_url = self._data_url_re.match(url)
         charset = None
         if data_url is not None:

--- a/test/tm-cases/backslash_escape_empty_links.html
+++ b/test/tm-cases/backslash_escape_empty_links.html
@@ -1,0 +1,4 @@
+<p><a href="">link</a></p>
+
+<p>one<br />
+two</p>

--- a/test/tm-cases/backslash_escape_empty_links.opts
+++ b/test/tm-cases/backslash_escape_empty_links.opts
@@ -1,0 +1,1 @@
+{"extras": {"breaks": {"on_backslash": True}}}

--- a/test/tm-cases/backslash_escape_empty_links.text
+++ b/test/tm-cases/backslash_escape_empty_links.text
@@ -1,0 +1,4 @@
+[link]()
+
+one\
+two


### PR DESCRIPTION
This PR fixes #648.

Empty links would have their URLs hashed to prevent them from being muddled with. Since the links were empty, that meant we were inserting an empty record into the hash table: `self._escape_table[''] = _hash_text(...)`

This empty record caused havok in regexes. I fixed this by checking for empty URLs and returning early.