### PR TITLE
Fix missing toxfile in sdist (#655)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     platforms=["any"],
     py_modules=["markdown2"],
     package_dir={"": "lib"},
+    data_files=[("testing", ["tox.ini"])],
     entry_points={
         "console_scripts": [
             "markdown2 = markdown2:main"


### PR DESCRIPTION
This PR fixes #655.

Added `tox.ini` file as a data file that is included in the sdist