### PR TITLE
Fix DoS in GFM emphasis processing (#668)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2574,7 +2574,9 @@ class GFMItalicAndBoldProcessor(Extra):
 
     def run(self, text):
         nesting = True
-        while nesting:
+        orig_text = ""
+        while nesting and orig_text != _hash_text(text):
+            orig_text = _hash_text(text)
             nesting = False
 
             opens = {'*': [], '_': []}

--- a/test/test_redos.py
+++ b/test/test_redos.py
@@ -37,17 +37,23 @@ def issue_633():
     # https://github.com/trentm/python-markdown2/issues/633
     return '<p m="1"' * 2500 + " " * 5000 + "</div"
 
+def issue_668():
+    # https://github.com/trentm/python-markdown2/issues/668
+    # not technically a redos, but still an error that caused a DOS
+    return 'a_b **x***y* c_d'
+
 
 # whack everything in a dict for easy lookup later on
 CASES = {
-    fn.__name__: fn
-    for fn in [
-        pull_387_example_1,
-        pull_387_example_2,
-        pull_387_example_3,
-        pull_402,
-        issue493,
-        issue_633,
+    fn.__name__: (fn, extras)
+    for fn, extras in [
+        (pull_387_example_1, None),
+        (pull_387_example_2, None),
+        (pull_387_example_3, None),
+        (pull_402, None),
+        (issue493, None),
+        (issue_633, None),
+        (issue_668, ['code-friendly']),
     ]
 }
 
@@ -60,7 +66,7 @@ if __name__ == "__main__":
         sys.path.insert(0, str(LIB_DIR))
         from markdown2 import markdown
 
-        markdown(testcase())
+        markdown(testcase[0](), extras=testcase[1])
         sys.exit(0)
 
     print("-- ReDoS tests")


### PR DESCRIPTION
This PR fixes #668.

The problem was with the following input using the code-friendly extra:
```
a_b **x***y* c_d
```
Code friendly piggy-backs off of the GFM IAB processor and disables `_` and `__` for em and strong. It works by detecting valid em/strong with this syntax and then hashing it to protect it. Otherwise, it just leaves it alone.

The GFM IAB processor works by matching delimiter runs, `*` or `_` syntax, and incrementing an index to keep track of how much of the input it has processed. For the above input it would follow roughly this process:
1. Match the first `_`. It's an opening run. Save for later
2. Match the `**`.  It's an opening run. Save for later
    - Match the `***`. It's an opening AND closing run. *Process now*
    - Code friendly looks at it and decides to leave it alone, as it's not relevant to the code friendly extra
    - `index` is set to after `***` as this span has been "processed"
3. Match the `*`, process now, index incremented
4. Match the final `_`. It's a closing run, process now
    - Look for a valid opening run, except the first `_` is before `index`. Usually means nested em has happened. Re-run the loop

Since the text hasn't actually changed, this loop runs forever.

To fix this, I've just added an extra condition to the loop that runs when nested em is detected.
We hash the input text and only continue the loop as long as the text is altered. If the text remains un-altered after a full iteration, we exit.

I've used `_hash_text` here, although maybe in the future a faster hash could be used if performance becomes an issue. #619 springs to mind, or a quick google suggested the FNV hash. Something for a future PR