### PR TITLE
Remove license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ finally:
 classifiers = """\
 Development Status :: 5 - Production/Stable
 Intended Audience :: Developers
-License :: OSI Approved :: MIT License
 Programming Language :: Python
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.9


### PR DESCRIPTION
License classifiers are deprecated in favor of SPDX license expressions. This patch gets rid of the according warning during the build process for a wheel.