### PR TITLE
Fix wrongly installing `testing` directory

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include CHANGES.md
 include Makefile
 include setup.py
 include setup.cfg
+include tox.ini
 
 include bin/markdown2
 include test/api.doctests

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     platforms=["any"],
     py_modules=["markdown2"],
     package_dir={"": "lib"},
-    data_files=[("testing", ["tox.ini"])],
     entry_points={
         "console_scripts": [
             "markdown2 = markdown2:main"


### PR DESCRIPTION
The fix for #655 introduced a regression: the package now installs a `/usr/testing` directory. Fix the issue correctly by adding the file to the source distribution via `MANIFEST.in`.