### PR TITLE
Fix XSS issue from incomplete tags with no attributes (#694)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - [pull #687] Fix AssertionError hashing HTML blocks spread over multiple lines (#686)
 - [pull #692] Fix XSS from code spans in link titles (#691)
+- [pull #695] Fix XSS issue from incomplete tags with no attributes (#694)
 
 
 ## python-markdown2 2.5.5

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -2215,7 +2215,7 @@ class Markdown:
         text = self._naked_gt_re.sub('&gt;', text)
         return text
 
-    _incomplete_tags_re = re.compile(r"\\*<(!--|/?\w+?(?!\w)\s*?.+?(?:[\s/]+?|$))")
+    _incomplete_tags_re = re.compile(r"\\*<(!--|/?\w+?(?!\w)\s*?.*?(?:[\s/]+?|$))")
 
     def _encode_incomplete_tags(self, text: str) -> str:
         if self.safe_mode not in ("replace", "escape"):

--- a/test/tm-cases/incomplete_tag_xss_issue694.html
+++ b/test/tm-cases/incomplete_tag_xss_issue694.html
@@ -1,0 +1,2 @@
+<p>&lt;iframe
+&lt;http:&gt; srcdoc="&lt;script&gt;alert()&lt;/script&gt;" a=</p>

--- a/test/tm-cases/incomplete_tag_xss_issue694.opts
+++ b/test/tm-cases/incomplete_tag_xss_issue694.opts
@@ -1,0 +1,1 @@
+{'safe_mode': 'escape'}

--- a/test/tm-cases/incomplete_tag_xss_issue694.text
+++ b/test/tm-cases/incomplete_tag_xss_issue694.text
@@ -1,0 +1,2 @@
+<iframe
+<http:> srcdoc="<script>alert()</script>" a=


### PR DESCRIPTION
This PR fixes #694.

Seems to stem from the incomplete tags regex not matching incomplete tags if they don't have any attrs. This PR tweaks the regex to allow for this case