### PR TITLE
Add py.typed marker for PEP 561 compliance

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include CHANGES.md
 include Makefile
 include setup.py
 include setup.cfg
+include lib/py.typed
 
 include bin/markdown2
 include test/api.doctests


### PR DESCRIPTION
Closes #696

## Problem

Type checkers (mypy, pyright) report that the  module is missing stubs/py.typed marker, even though typing support was added in PR #581.

```
mypy: Skipping analyzing "markdown2": module is installed, but missing library stubs or py.typed marker
pyright: Stub file not found for "markdown2"
```

## Solution

Add a PEP 561  marker file to signal to type checkers that the package ships inline type information.

## Changes

- **Added ** — empty marker file per [PEP 561](https://peps.python.org/pep-0561/)
- **Updated ** — includes  in source distributions

## Testing

After installing the package with this change, both mypy and pyright will recognize  as a typed package without requiring separate stubs.