### PR TITLE
fix: decode HTML entities before slugifying header IDs

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -116,6 +116,7 @@ __version__ = '.'.join(map(str, __version_info__))
 __author__ = "Trent Mick"
 
 import argparse
+import html
 import logging
 import re
 import sys
@@ -1578,7 +1579,7 @@ class Markdown:
             None to not have an id attribute and to exclude this header from
             the TOC (if the "toc" extra is specified).
         """
-        header_id = _slugify(text)
+        header_id = _slugify(html.unescape(text))
         if prefix and isinstance(prefix, str):
             header_id = prefix + '-' + header_id
 

--- a/test/tm-cases/header_ids_entity.html
+++ b/test/tm-cases/header_ids_entity.html
@@ -1,0 +1,5 @@
+<h1 id="escaped-lt">&lt;escaped-lt</h1>
+
+<h1 id="rd-notes">R&amp;D Notes</h1>
+
+<h1 id="normal-header">Normal Header</h1>

--- a/test/tm-cases/header_ids_entity.opts
+++ b/test/tm-cases/header_ids_entity.opts
@@ -1,0 +1,1 @@
+{"extras": ["header-ids"]}

--- a/test/tm-cases/header_ids_entity.text
+++ b/test/tm-cases/header_ids_entity.text
@@ -1,0 +1,5 @@
+# &lt;escaped-lt
+
+# R&amp;D Notes
+
+# Normal Header


### PR DESCRIPTION
## Summary

Fixes #649.

When a markdown header contains HTML entities such as `&lt;`, `&amp;`, or `&gt;`, the `header_id_from_text` method passes the raw entity string to `_slugify` *before* HTML-decoding it.

The `&` and `;` characters are stripped by `_slugify` as non-word characters, but the entity name letters (e.g. `lt`) survive and pollute the generated ID:

```python
import markdown2
result = markdown2.markdown("# &lt;othertext", extras={"header-ids": None})
# Actual:   <h1 id="ltothertext">&lt;othertext</h1>
# Expected: <h1 id="othertext">&lt;othertext</h1>
```

## Fix

Call `html.unescape()` on the header text before slugifying, so entity characters are decoded to their actual Unicode code points first. The resulting characters are then stripped or kept by `_slugify` as any literal character would be:

```python
# lib/markdown2.py — header_id_from_text()
- header_id = _slugify(text)
+ header_id = _slugify(html.unescape(text))
```

This is a one-line fix plus a new test case (`test/tm-cases/header_ids_entity.*`).

## Tested

- `# &lt;othertext` → `id="othertext"` ✓ (was `id="ltothertext"`)
- `# R&amp;D` → `id="rd"` ✓ (was `id="rampd"`)
- `# <sometext>` → `id="sometext"` ✓ (unchanged, still correct)
- All existing `header_ids_*` test cases pass.
- No new test failures introduced (12 pre-existing failures are unchanged).

This pull request was prepared with the assistance of AI, under my direction and review.