### PR TITLE
Fix header-ids extra generating duplicate ids (#661)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 - [pull #701] Allow boolean attribute syntax in `markdown-in-html` extra
 - [pull #704] Fix XSS from smuggling spans into image attributes (#702, #703)
 - [pull #710] Add emoji support (#709)
-- Fix `header-ids` extra generating duplicate ids when a suffixed id collides with another header (#661)
+- [pull #713] Fix `header-ids` extra generating duplicate ids when a suffixed id collides with another header (#661)
 
 
 ## python-markdown2 2.5.5

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - [pull #701] Allow boolean attribute syntax in `markdown-in-html` extra
 - [pull #704] Fix XSS from smuggling spans into image attributes (#702, #703)
 - [pull #710] Add emoji support (#709)
+- Fix `header-ids` extra generating duplicate ids when a suffixed id collides with another header (#661)
 
 
 ## python-markdown2 2.5.5

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -412,6 +412,8 @@ class Markdown:
         if "header-ids" in self.extras:
             if not hasattr(self, '_count_from_header_id') or self.extras['header-ids'].get('reset-count', False):
                 self._count_from_header_id = defaultdict(int)
+            if not hasattr(self, '_header_ids_seen') or self.extras['header-ids'].get('reset-count', False):
+                self._header_ids_seen = set()
         if "metadata" in self.extras:
             self.metadata: dict[str, Any] = {}
 
@@ -1582,9 +1584,17 @@ class Markdown:
         if prefix and isinstance(prefix, str):
             header_id = prefix + '-' + header_id
 
-        self._count_from_header_id[header_id] += 1
-        if 0 == len(header_id) or self._count_from_header_id[header_id] > 1:
-            header_id += '-%s' % self._count_from_header_id[header_id]
+        base_id = header_id
+        self._count_from_header_id[base_id] += 1
+        if 0 == len(base_id) or self._count_from_header_id[base_id] > 1:
+            header_id = '%s-%s' % (base_id, self._count_from_header_id[base_id])
+        # A suffixed id may still collide with a differently-named header
+        # (e.g. "# Chapter" twice yields "chapter-2", which clashes with
+        # "# Chapter 2"). Keep bumping until the id is genuinely unique.
+        while header_id in self._header_ids_seen:
+            self._count_from_header_id[base_id] += 1
+            header_id = '%s-%s' % (base_id, self._count_from_header_id[base_id])
+        self._header_ids_seen.add(header_id)
 
         return header_id
 

--- a/test/tm-cases/header_ids_duplicate.html
+++ b/test/tm-cases/header_ids_duplicate.html
@@ -1,0 +1,11 @@
+<h1 id="chapter">Chapter</h1>
+
+<p>Test</p>
+
+<h1 id="chapter-2">Chapter</h1>
+
+<p>Test</p>
+
+<h1 id="chapter-2-2">Chapter 2</h1>
+
+<p>Test</p>

--- a/test/tm-cases/header_ids_duplicate.opts
+++ b/test/tm-cases/header_ids_duplicate.opts
@@ -1,0 +1,1 @@
+{"extras": ["header-ids"]}

--- a/test/tm-cases/header_ids_duplicate.tags
+++ b/test/tm-cases/header_ids_duplicate.tags
@@ -1,0 +1,1 @@
+extra header-ids issue661

--- a/test/tm-cases/header_ids_duplicate.text
+++ b/test/tm-cases/header_ids_duplicate.text
@@ -1,0 +1,11 @@
+# Chapter
+
+Test
+
+# Chapter
+
+Test
+
+# Chapter 2
+
+Test


### PR DESCRIPTION
## Summary

The `header-ids` extra can emit duplicate `id` attributes (#661).

De-duplication relied only on a per-base-slug counter. When that counter is appended to a base slug, the resulting id can collide with a *differently-named* header whose own slug happens to equal the suffixed value:

```
# Chapter
# Chapter
# Chapter 2
```

produced:

```html
<h1 id="chapter">Chapter</h1>
<h1 id="chapter-2">Chapter</h1>
<h1 id="chapter-2">Chapter 2</h1>   <!-- duplicate of the line above -->
```

The second `# Chapter` becomes `chapter-2`, and `# Chapter 2` also slugifies to the base `chapter-2`, which was emitted verbatim.

## Fix

`header_id_from_text` now tracks the set of ids it has already emitted. After building the candidate id it keeps bumping the base-slug counter until the id is genuinely unique, so the third header becomes `chapter-2-2`:

```html
<h1 id="chapter">Chapter</h1>
<h1 id="chapter-2">Chapter</h1>
<h1 id="chapter-2-2">Chapter 2</h1>
```

The change preserves the existing `-N` suffix convention (e.g. duplicate `Intro` -> `intro-2`, as covered by `header_ids_5`) and the `reset-count` behavior for persistent `Markdown` objects; the new seen-set is reset in lockstep with the existing counter.

## Tests / Verification

- Added a `tm-cases` regression test (`header_ids_duplicate`) using the exact repro from the issue. It fails on `master` (produced a duplicate `chapter-2`) and passes with this fix.
- Full test suite run: no new failures. The 14 remaining failures are all pre-existing and tagged `knownfailure` (unrelated to this change).
- Added a `CHANGES.md` entry under the unreleased section.

Disclosure: prepared with AI assistance; reviewed and verified locally.
