### PR TITLE
Fix IndexError in metadata extra on documents with no metadata split

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -632,12 +632,21 @@ class Markdown:
     def _extract_metadata(self, text: str) -> str:
         if text.startswith("---"):
             fence_splits = re.split(self._meta_data_fence_pattern, text, maxsplit=2)
+            if len(fence_splits) < 3:
+                # A leading '---' with no closing fence is a horizontal rule (or
+                # unterminated front matter), not metadata. re.split returns
+                # fewer than three elements in that case, so leave text as-is.
+                return text
             metadata_content = fence_splits[1]
             tail = fence_splits[2]
         else:
             metadata_split = re.split(self._meta_data_newline, text, maxsplit=1)
             metadata_content = metadata_split[0]
-            tail = metadata_split[1]
+            # There is no blank line to split on when the whole document is a
+            # single block (e.g. a tab-indented code block with no trailing
+            # blank line), so re.split returns a single element and there is
+            # no document body after the metadata.
+            tail = metadata_split[1] if len(metadata_split) > 1 else ""
 
         # _meta_data_pattern only has one capturing group, so we can assume
         # the returned type to be list[str]

--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -272,6 +272,41 @@ versions of markdown2.py this was pathologically slow:</p>
             '<h2>%s</h2>\n' % ko)
     test_russian.tags = ["unicode", "issue3"]
 
+    def test_metadata_no_blank_line(self):
+        # A single-block document with no blank line (e.g. a tab-indented code
+        # block) gives the metadata extra nothing to split on, so re.split
+        # returns a single element. This used to raise IndexError; it should
+        # render normally with no metadata extracted.
+        result = markdown2.markdown('\tsome indented code', extras=['metadata'])
+        self.assertEqual(result, '<pre><code>some indented code\n</code></pre>\n')
+        self.assertEqual(result.metadata, {})
+    test_metadata_no_blank_line.tags = ["metadata", "issue"]
+
+    def test_metadata_leading_hr_no_closing_fence(self):
+        # A document that opens with '---' (a horizontal rule) but has no
+        # closing '---' fence is not front matter. This used to raise
+        # IndexError; it should render the '---' as an <hr>.
+        result = markdown2.markdown('---\n# My Document\n', extras=['metadata'])
+        self.assertEqual(result, '<hr />\n\n<h1>My Document</h1>\n')
+        self.assertEqual(result.metadata, {})
+    test_metadata_leading_hr_no_closing_fence.tags = ["metadata", "issue"]
+
+    def test_metadata_fenced_front_matter_still_parsed(self):
+        # A complete '---' fenced front-matter block is still extracted.
+        result = markdown2.markdown('---\ntitle: Hi\n---\n# Body\n',
+                                    extras=['metadata'])
+        self.assertEqual(result.metadata, {'title': 'Hi'})
+        self.assertEqual(result, '<h1>Body</h1>\n')
+    test_metadata_fenced_front_matter_still_parsed.tags = ["metadata"]
+
+    def test_metadata_still_parsed_without_fence(self):
+        # The fix must not change how leading key: value metadata is parsed.
+        result = markdown2.markdown('title: Hello\nauthor: Me\n\n# Body\n',
+                                    extras=['metadata'])
+        self.assertEqual(result.metadata, {'title': 'Hello', 'author': 'Me'})
+        self.assertEqual(result, '<h1>Body</h1>\n')
+    test_metadata_still_parsed_without_fence.tags = ["metadata"]
+
     def test_toc_with_persistent_object(self):
         """
         Tests that the toc is the same every time it's run on HTML, even if the Markdown object isn't disposed of.


### PR DESCRIPTION
`_extract_metadata` assumes `re.split` yields enough parts to index, so two common inputs crash the `metadata` extra with `IndexError: list index out of range`:

- A document opening with `---` (a horizontal rule) but with no closing `---` fence: the fenced branch indexes `fence_splits[1]`/`[2]` but the split returns fewer than three parts. Example: `markdown2.markdown('---\n# My Document\n', extras=['metadata'])`.
- A single-block document with no blank line, such as a tab-indented code block: the non-fenced branch indexes `metadata_split[1]` but the split returns a single part. Example: `markdown2.markdown('\tsome indented code', extras=['metadata'])`.

This guards both branches: a leading `---` with no closing fence is left unchanged (rendered as an `<hr>`), and a missing tail is treated as an empty body. Valid `---` fenced and leading `key: value` metadata still parse. Added regression tests for both crash cases and the two preservation cases; the full suite passes.