### PR TITLE
Fix TypeError when 'breaks' and 'break-on-newline' extras are combined

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -366,7 +366,13 @@ class Markdown:
                 }
 
         if 'break-on-newline' in self.extras:
-            self.extras.setdefault('breaks', {})
+            # `break-on-newline` is an alias for the breaks extra's `on_newline`
+            # option. When both extras are given (e.g. extras=['breaks',
+            # 'break-on-newline']) `breaks` is already a key mapped to None, so
+            # setdefault would leave it None and the assignment below would
+            # raise a TypeError. Normalise to a dict before setting the option.
+            if not isinstance(self.extras.get('breaks'), dict):
+                self.extras['breaks'] = {}
             self.extras['breaks']['on_newline'] = True
 
         if 'link-patterns' in self.extras:

--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -272,6 +272,30 @@ versions of markdown2.py this was pathologically slow:</p>
             '<h2>%s</h2>\n' % ko)
     test_russian.tags = ["unicode", "issue3"]
 
+    def test_breaks_and_break_on_newline_together(self):
+        # `break-on-newline` is an alias for the breaks extra; supplying both
+        # in the common list form used to raise TypeError during setup.
+        expected = '<p>a<br />\nb</p>\n'
+        self.assertEqual(
+            markdown2.markdown('a\nb', extras=['breaks', 'break-on-newline']),
+            expected)
+        self.assertEqual(
+            markdown2.markdown('a\nb', extras=['break-on-newline', 'breaks']),
+            expected)
+        # Each alone keeps its documented behaviour.
+        self.assertEqual(
+            markdown2.markdown('a\nb', extras=['break-on-newline']), expected)
+        self.assertEqual(
+            markdown2.markdown('a\nb', extras=['breaks']), '<p>a\nb</p>\n')
+        # A breaks dict with other options is preserved, not overwritten.
+        self.assertEqual(
+            markdown2.markdown(
+                'a\\\nb',
+                extras={'breaks': {'on_backslash': True},
+                        'break-on-newline': None}),
+            '<p>a<br />\nb</p>\n')
+    test_breaks_and_break_on_newline_together.tags = ["breaks", "extras"]
+
     def test_toc_with_persistent_object(self):
         """
         Tests that the toc is the same every time it's run on HTML, even if the Markdown object isn't disposed of.


### PR DESCRIPTION
Passing both `breaks` and `break-on-newline` in the usual list form (e.g. `extras=['breaks', 'break-on-newline']`) raised `TypeError: 'NoneType' object does not support item assignment` during `Markdown.__init__`.

`break-on-newline` is an alias for the breaks extra's `on_newline` option, so the setup does `self.extras.setdefault('breaks', {}); self.extras['breaks']['on_newline'] = True`. When both extras are given, `breaks` is already a key mapped to `None`, so `setdefault` is a no-op and the assignment into `None` fails.

Normalise the value to a dict first, preserving an existing `breaks` dict so other breaks options are not overwritten. Adds a regression test covering both orderings, each extra alone, and the dict form.