### PR TITLE
Security: Use of `eval()` on file contents

### DIFF
--- a/perf/strip_cookbook_data.py
+++ b/perf/strip_cookbook_data.py
@@ -1,10 +1,11 @@
 from os.path import *
 from pprint import pformat
+import ast
 
 def doit():
     recipes_path = expanduser("recipes.pprint")
     with open(recipes_path) as f:
-        recipe_dicts = eval(f.read())
+        recipe_dicts = ast.literal_eval(f.read())
     for r in recipe_dicts:
         for key in r.keys():
             if key not in ('desc', 'comments'):


### PR DESCRIPTION
## Summary

Security: Use of `eval()` on file contents

## Problem

**Severity**: `High` | **File**: `perf/strip_cookbook_data.py:L8`

The `doit()` function in `perf/strip_cookbook_data.py` uses `eval(f.read())` to parse the contents of a file. If the file is untrusted or compromised, this could lead to arbitrary code execution.

## Solution

Replace `eval()` with a safe deserialization format like `json.loads()` or `ast.literal_eval()`.

## Changes

- `perf/strip_cookbook_data.py` (modified)