### PR TITLE
Treat head and style as block-level tags (#331)

### DIFF
--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -901,7 +901,7 @@ class Markdown:
         """ % _block_tags_a,
         re.X | re.M)
 
-    _block_tags_b = 'blockquote|div|dl|fieldset|form|h[1-6]|iframe|math|noscript|ol|p|pre|script|table|ul'
+    _block_tags_b = 'blockquote|div|dl|fieldset|form|h[1-6]|head|iframe|math|noscript|ol|p|pre|script|style|table|ul'
     _block_tags_b += _html5tags
 
     _span_tags = (

--- a/test/test_markdown2.py
+++ b/test/test_markdown2.py
@@ -272,6 +272,18 @@ versions of markdown2.py this was pathologically slow:</p>
             '<h2>%s</h2>\n' % ko)
     test_russian.tags = ["unicode", "issue3"]
 
+    def test_head_and_style_block_tags(self):
+        # `head` and `style` are block-level, but were missing from the
+        # liberal block-tag list, so a single-line `<style>...</style>` (or
+        # `<head>`) got wrapped in a spurious `<p>`.
+        self._assertMarkdown(
+            '<style>body { margin-left: 1.25cm; }</style>',
+            '<style>body { margin-left: 1.25cm; }</style>\n')
+        self._assertMarkdown(
+            '<head><meta charset="UTF-8"></head>',
+            '<head><meta charset="UTF-8"></head>\n')
+    test_head_and_style_block_tags.tags = ["html", "issue331"]
+
     def test_breaks_and_break_on_newline_together(self):
         # `break-on-newline` is an alias for the breaks extra; supplying both
         # in the common list form used to raise TypeError during setup.


### PR DESCRIPTION
Closes #331

`<head>` and `<style>` are in `_block_tags_a` (the strict nested-block matcher) but were missing from `_block_tags_b`, which drives the liberal `\n<tag>`...`</tag>\n` matcher — so a single-line `<style>body { margin-left: 1.25cm; }</style>` was never hashed as an HTML block and got wrapped in a spurious `<p>`. Adding both to `_block_tags_b` matches how div/table/script/pre are already declared in both lists.

Regression test added in `test/test_markdown2.py` (`DirectTestCase`); it fails on master and passes with the fix. Full suite is unchanged otherwise (same 16 pre-existing failures before and after).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
